### PR TITLE
Add display mode to media player card and fix bottom bar visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,6 @@ speaker_group:
 
 A full-sized media player card made for panel view. This card gives you an immersive media control experience with all features at a glance.
 
-**Note: This card is meant for panel view only and doesn't work well in dashboards.**
-
 <img src="https://github.com/user-attachments/assets/8340e509-c7af-4a10-bbb1-8b8086a87e57" width="500px" alt="Mediocre Massive Media Player Card Screenshot" />
 
 #### Configuration
@@ -53,6 +51,7 @@ A full-sized media player card made for panel view. This card gives you an immer
 ```yaml
 type: "custom:mediocre-massive-media-player-card"
 entity_id: media_player.living_room_speaker
+mode: panel # Options: panel, card, in-card
 speaker_group:
   entities:
     - media_player.kitchen_speaker
@@ -71,6 +70,12 @@ Both cards support these options:
 | `speaker_group.entity_id` | string | -        | Entity ID of the main speaker if different from the media player |
 | `speaker_group.entities`  | array  | -        | List of entity IDs that can be grouped with the main speaker     |
 | `custom_buttons`          | array  | -        | List of custom buttons to display                                |
+
+The Mediocre Massive Media Player Card has additional options:
+
+| Option | Type   | Default | Description                                 |
+| ------ | ------ | ------- | ------------------------------------------- |
+| `mode` | string | `panel` | Display mode: `panel`, `card`, or `in-card` |
 
 ### Action Configuration
 

--- a/src/cards/mediocre-massive-media-player-card.tsx
+++ b/src/cards/mediocre-massive-media-player-card.tsx
@@ -1,11 +1,12 @@
+import { HomeAssistant } from "custom-card-helpers";
 import { MediocreMassiveMediaPlayerCard } from "../components";
-import { MediocreMediaPlayerCardConfig } from "../components/MediaPlayerCommon";
+import { MediocreMassiveMediaPlayerCardConfig } from "../components/MediaPlayerCommon";
 import { CardWrapper } from "../utils";
 
-class MediocreMassiveMediaPlayerCardWrapper extends CardWrapper<MediocreMediaPlayerCardConfig> {
+class MediocreMassiveMediaPlayerCardWrapper extends CardWrapper<MediocreMassiveMediaPlayerCardConfig> {
   Card = MediocreMassiveMediaPlayerCard;
 
-  setConfig(config: MediocreMediaPlayerCardConfig) {
+  setConfig(config: MediocreMassiveMediaPlayerCardConfig) {
     if (!config.entity_id) {
       throw new Error("You need to define an entity_id");
     }
@@ -13,7 +14,19 @@ class MediocreMassiveMediaPlayerCardWrapper extends CardWrapper<MediocreMediaPla
   }
 
   static getConfigElement() {
-    return document.createElement("mediocre-media-player-card-editor");
+    return document.createElement("mediocre-massive-media-player-card-editor");
+  }
+
+  static getStubConfig(hass: HomeAssistant) {
+    const entities = Object.keys(hass.states);
+    const mediaPlayers = entities.filter(
+      (entity) => entity.substr(0, entity.indexOf(".")) === "media_player"
+    );
+
+    return {
+      entity_id: mediaPlayers[0] ?? "",
+      mode: "card",
+    };
   }
 }
 
@@ -26,8 +39,8 @@ window.customCards = window.customCards || [];
 window.customCards.push({
   type: "mediocre-massive-media-player-card",
   name: "Mediocre Massive Media Player Card",
-  preview: false, // Optional - defaults to false
-  description: "A media player card with player grouping support", // Optional
+  preview: true,
+  description: "A media player card with player grouping support.", // Optional
   documentationURL:
     "https://developers.home-assistant.io/docs/frontend/custom-ui/custom-card", // Adds a help link in the frontend card editor
 });

--- a/src/cards/mediocre-media-player-card-editor.tsx
+++ b/src/cards/mediocre-media-player-card-editor.tsx
@@ -8,6 +8,16 @@ class MediocreMediaPlayerCardEditorWrapper extends CardEditorWrapper<MediocreMed
   Card = MediocreMediaPlayerCardEditor;
 }
 
+class MediocreMassiveMediaPlayerCardEditorWrapper extends CardEditorWrapper<MediocreMediaPlayerCardConfig> {
+  Card = MediocreMediaPlayerCardEditor;
+  extraProps = { isMassive: true };
+}
+
+customElements.define(
+  "mediocre-massive-media-player-card-editor",
+  MediocreMassiveMediaPlayerCardEditorWrapper
+);
+
 customElements.define(
   "mediocre-media-player-card-editor",
   MediocreMediaPlayerCardEditorWrapper

--- a/src/cards/mediocre-media-player-card.tsx
+++ b/src/cards/mediocre-media-player-card.tsx
@@ -1,3 +1,4 @@
+import { HomeAssistant } from "custom-card-helpers";
 import { MediocreMediaPlayerCard } from "../components";
 import { MediocreMediaPlayerCardConfig } from "../components/MediaPlayerCommon";
 import { CardWrapper } from "../utils";
@@ -14,6 +15,19 @@ class MediocreMediaPlayerCardWrapper extends CardWrapper<MediocreMediaPlayerCard
 
   static getConfigElement() {
     return document.createElement("mediocre-media-player-card-editor");
+  }
+
+  static getStubConfig(hass: HomeAssistant) {
+    console.log("here");
+    const entities = Object.keys(hass.states);
+    const mediaPlayers = entities.filter(
+      (entity) => entity.substr(0, entity.indexOf(".")) === "media_player"
+    );
+    console.log("mediaPlayers", mediaPlayers);
+
+    return {
+      entity_id: mediaPlayers[0] ?? "",
+    };
   }
 
   getCardSize() {
@@ -37,8 +51,8 @@ window.customCards = window.customCards || [];
 window.customCards.push({
   type: "mediocre-media-player-card",
   name: "Mediocre Media Player Card",
-  preview: false, // Optional - defaults to false
-  description: "A media player card with player grouping support", // Optional
+  preview: true,
+  description: "A media player card with player grouping support.", // Optional
   documentationURL:
     "https://developers.home-assistant.io/docs/frontend/custom-ui/custom-card", // Adds a help link in the frontend card editor
 });

--- a/src/components/FormElements/Select.tsx
+++ b/src/components/FormElements/Select.tsx
@@ -1,0 +1,22 @@
+import { FC } from "preact/compat";
+
+export type Select = {
+  options: { name: string; value: string }[];
+  onSelected: (value: string) => void;
+  selected: string;
+};
+
+export const Select: FC<Select> = ({ options, onSelected, selected }) => {
+  return (
+    <select
+      value={selected}
+      onChange={(e) => onSelected((e.target as HTMLSelectElement).value)}
+    >
+      {options.map((option) => (
+        <option key={option.value} value={option.value}>
+          {option.name}
+        </option>
+      ))}
+    </select>
+  );
+};

--- a/src/components/FormElements/index.ts
+++ b/src/components/FormElements/index.ts
@@ -2,4 +2,5 @@ export * from "./ActionConfigurator";
 export * from "./EntitiesPicker";
 export * from "./EntityPicker";
 export * from "./InteractionsPicker";
+export * from "./Select";
 export * from "./TextInput";

--- a/src/components/MediaPlayerCommon/MediocreMediaPlayerCardEditor.tsx
+++ b/src/components/MediaPlayerCommon/MediocreMediaPlayerCardEditor.tsx
@@ -1,11 +1,15 @@
 import { HomeAssistant } from "custom-card-helpers";
-import { MediocreMediaPlayerCardConfig } from "../MediaPlayerCommon/config";
+import {
+  MediocreMassiveMediaPlayerCardConfig,
+  MediocreMediaPlayerCardConfig,
+} from "../MediaPlayerCommon/config";
 import { useCallback } from "preact/hooks";
 import styled from "@emotion/styled";
 import {
   EntitiesPicker,
   EntityPicker,
   InteractionsPicker,
+  Select,
   TextInput,
 } from "../FormElements";
 import { SubForm } from "../SubForm/SubForm";
@@ -54,15 +58,20 @@ const InputGroup = styled.div`
   margin-bottom: 16px;
 `;
 
+export type MediocreMediaPlayerCardEditorProps = {
+  rootElement: HTMLElement;
+  hass: HomeAssistant;
+} & (
+  | { config: MediocreMediaPlayerCardConfig; isMassive?: false }
+  | { config: MediocreMassiveMediaPlayerCardConfig; isMassive: true }
+);
+
 export const MediocreMediaPlayerCardEditor = ({
   config,
   rootElement,
   hass,
-}: {
-  config: MediocreMediaPlayerCardConfig;
-  rootElement: HTMLElement;
-  hass: HomeAssistant;
-}) => {
+  isMassive,
+}: MediocreMediaPlayerCardEditorProps) => {
   if (!config || !hass || !rootElement) {
     console.error("No config or hass");
   }
@@ -184,6 +193,20 @@ export const MediocreMediaPlayerCardEditor = ({
           required
         />
       </FormGroup>
+
+      {isMassive && (
+        <SubForm title="Display Mode">
+          <Select
+            options={[
+              { name: "Panel", value: "panel" },
+              { name: "Card", value: "card" },
+              { name: "In Card", value: "in-card" },
+            ]}
+            onSelected={(value) => updateField("mode", value)}
+            selected={config.mode || "panel"}
+          />
+        </SubForm>
+      )}
 
       <FormGroup>
         <SubForm title="Interactions">

--- a/src/components/MediaPlayerCommon/config.ts
+++ b/src/components/MediaPlayerCommon/config.ts
@@ -12,3 +12,8 @@ export type MediocreMediaPlayerCardConfig = {
     name: string;
   })[];
 };
+
+export type MediocreMassiveMediaPlayerCardConfig =
+  MediocreMediaPlayerCardConfig & {
+    mode: "panel" | "card" | "in-card";
+  };

--- a/src/components/MediocreMassiveMediaPlayerCard/MediocreMassiveMediaPlayerCard.tsx
+++ b/src/components/MediocreMassiveMediaPlayerCard/MediocreMassiveMediaPlayerCard.tsx
@@ -2,35 +2,71 @@ import { AlbumArt, Title, Track } from "./components";
 import { PlaybackControls } from "./components/PlaybackControls";
 import styled from "@emotion/styled";
 import { PlayerActions } from "./components/PlayerActions";
+import { useContext } from "preact/hooks";
+import { CardContext, CardContextType } from "../../utils";
+import { MediocreMassiveMediaPlayerCardConfig } from "../MediaPlayerCommon";
 
-const Root = styled.div`
+const Root = styled.div<{
+  mode: MediocreMassiveMediaPlayerCardConfig["mode"];
+}>`
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 100%;
-  height: 100%;
-  // Below gradient transitions from panel header color to transparent
-  background: linear-gradient(
-    var(--app-header-background-color),
-    rgba(255, 255, 255, 0)
-  );
-  max-height: calc(100vh - var(--header-height, 16px));
+  ${(props) => {
+    switch (props?.mode) {
+      case "panel": {
+        return `
+          width: 100%;
+          height: 100%;
+          // Below gradient transitions from panel header color to transparent
+          background: linear-gradient(
+            var(--app-header-background-color),
+            rgba(255, 255, 255, 0)
+          );
+          max-height: calc(100vh - var(--header-height, 16px));
+        `;
+      }
+      default: {
+        return ``;
+      }
+    }
+  }}
+
   box-sizing: border-box;
   * {
     box-sizing: border-box;
   }
 `;
 
-const Wrap = styled.div`
+const Wrap = styled.div<{
+  mode: MediocreMassiveMediaPlayerCardConfig["mode"];
+}>`
   display: flex;
   flex-direction: column;
   gap: 16px;
   justify-content: space-around;
   align-items: center;
-  width: 90%;
-  max-width: 400px;
   padding-top: 16px;
   padding-bottom: 16px;
+  ${(props) => {
+    switch (props?.mode) {
+      case "panel": {
+        return `
+          width: 90%;
+          max-width: 400px;
+        `;
+      }
+      case "card": {
+        return `
+          width: 100%;
+          padding: 16px;
+        `;
+      }
+      default: {
+        return "";
+      }
+    }
+  }}
   height: 100%;
 `;
 
@@ -45,9 +81,15 @@ const ControlsWrapper = styled.div`
 `;
 
 export const MediocreMassiveMediaPlayerCard = () => {
-  return (
-    <Root>
-      <Wrap>
+  const { config } =
+    useContext<CardContextType<MediocreMassiveMediaPlayerCardConfig>>(
+      CardContext
+    );
+  const { mode = "panel" } = config;
+
+  const renderRoot = () => (
+    <Root mode={mode}>
+      <Wrap mode={mode}>
         <AlbumArt />
         <ControlsWrapper>
           <Title />
@@ -58,4 +100,9 @@ export const MediocreMassiveMediaPlayerCard = () => {
       </Wrap>
     </Root>
   );
+
+  if (mode === "card") {
+    return <ha-card>{renderRoot()}</ha-card>;
+  }
+  return renderRoot();
 };

--- a/src/components/MediocreMassiveMediaPlayerCard/components/AlbumArt.tsx
+++ b/src/components/MediocreMassiveMediaPlayerCard/components/AlbumArt.tsx
@@ -4,7 +4,7 @@ import { CardContext, CardContextType } from "../../../utils";
 import { Vibrant } from "node-vibrant/browser";
 import { Icon } from "../../Icon";
 import { Fragment } from "preact/jsx-runtime";
-import { MediocreMediaPlayerCardConfig } from "../../MediaPlayerCommon";
+import { MediocreMassiveMediaPlayerCardConfig } from "../../MediaPlayerCommon";
 
 const ImgOuter = styled.div`
   display: flex;
@@ -45,7 +45,9 @@ const SourceIndicator = styled.div<{ contrastColor?: string }>`
 
 export const AlbumArt = () => {
   const { hass, config } =
-    useContext<CardContextType<MediocreMediaPlayerCardConfig>>(CardContext);
+    useContext<CardContextType<MediocreMassiveMediaPlayerCardConfig>>(
+      CardContext
+    );
   const { entity_id } = config;
   const player = hass.states[entity_id];
   const {

--- a/src/components/MediocreMassiveMediaPlayerCard/components/PlaybackControls.tsx
+++ b/src/components/MediocreMassiveMediaPlayerCard/components/PlaybackControls.tsx
@@ -3,7 +3,7 @@ import styled from "@emotion/styled";
 import { IconButton } from "../../IconButton";
 import { CardContext, CardContextType } from "../../../utils";
 import { useSupportedFeatures } from "../../../hooks";
-import { MediocreMediaPlayerCardConfig } from "../../MediaPlayerCommon";
+import { MediocreMassiveMediaPlayerCardConfig } from "../../MediaPlayerCommon";
 
 const PlaybackControlsWrap = styled.div`
   display: flex;
@@ -15,7 +15,9 @@ const PlaybackControlsWrap = styled.div`
 
 export const PlaybackControls = () => {
   const { hass, config } =
-    useContext<CardContextType<MediocreMediaPlayerCardConfig>>(CardContext);
+    useContext<CardContextType<MediocreMassiveMediaPlayerCardConfig>>(
+      CardContext
+    );
   const player = hass.states[config.entity_id];
 
   const {

--- a/src/components/MediocreMassiveMediaPlayerCard/components/PlayerActions.tsx
+++ b/src/components/MediocreMassiveMediaPlayerCard/components/PlayerActions.tsx
@@ -10,7 +10,7 @@ import { InteractionConfig } from "../../../types";
 import { Chip } from "../../Chip";
 import { Icon } from "../../Icon";
 import { useActionProps } from "../../../hooks";
-import { MediocreMediaPlayerCardConfig } from "../../MediaPlayerCommon";
+import { MediocreMassiveMediaPlayerCardConfig } from "../../MediaPlayerCommon";
 
 const PlaybackControlsWrap = styled.div`
   background-color: var(--card-background-color);
@@ -70,13 +70,11 @@ const ModalContent = styled.div<{ padding?: string }>`
 
 export const PlayerActions = () => {
   const { hass, config, rootElement } =
-    useContext<CardContextType<MediocreMediaPlayerCardConfig>>(CardContext);
+    useContext<CardContextType<MediocreMassiveMediaPlayerCardConfig>>(
+      CardContext
+    );
 
   const { entity_id, custom_buttons, speaker_group } = config;
-
-  if (!custom_buttons || custom_buttons.length === 0) {
-    return null;
-  }
 
   const [selected, setSelected] = useState<"volume" | "speaker-grouping">();
 
@@ -133,7 +131,7 @@ export const PlayerActions = () => {
         {...moreInfoButtonProps}
         icon="mdi:information"
       />
-      {custom_buttons.map((button, index) => (
+      {custom_buttons?.map((button, index) => (
         <CustomButton key={index} button={button} type={"icon-button"} />
       ))}
       <IconButton size="small" icon={"mdi:power"} onClick={onTogglePower} />
@@ -178,7 +176,9 @@ export const CustomButton = ({
   };
 }) => {
   const { hass, rootElement, config } =
-    useContext<CardContextType<MediocreMediaPlayerCardConfig>>(CardContext);
+    useContext<CardContextType<MediocreMassiveMediaPlayerCardConfig>>(
+      CardContext
+    );
   const { icon, name, ...actionConfig } = button;
   const actionProps = useActionProps({
     hass,

--- a/src/components/MediocreMassiveMediaPlayerCard/components/SpeakerGrouping.tsx
+++ b/src/components/MediocreMassiveMediaPlayerCard/components/SpeakerGrouping.tsx
@@ -5,7 +5,7 @@ import { IconButton } from "../../IconButton";
 import { CardContext, CardContextType } from "../../../utils";
 import { Fragment } from "preact/jsx-runtime";
 import { Icon } from "../../Icon";
-import { MediocreMediaPlayerCardConfig } from "../../MediaPlayerCommon";
+import { MediocreMassiveMediaPlayerCardConfig } from "../../MediaPlayerCommon";
 
 const SpeakerGroupContainer = styled.div`
   display: flex;
@@ -81,7 +81,9 @@ const Chip = styled.div<{ $loading: boolean }>`
 
 export const SpeakerGrouping = () => {
   const { hass, config } =
-    useContext<CardContextType<MediocreMediaPlayerCardConfig>>(CardContext);
+    useContext<CardContextType<MediocreMassiveMediaPlayerCardConfig>>(
+      CardContext
+    );
 
   const { entity_id, speaker_group } = config;
 

--- a/src/components/MediocreMassiveMediaPlayerCard/components/Title.tsx
+++ b/src/components/MediocreMassiveMediaPlayerCard/components/Title.tsx
@@ -1,7 +1,7 @@
 import { useContext } from "preact/hooks";
 import styled from "@emotion/styled";
 import { CardContext, CardContextType } from "../../../utils";
-import { MediocreMediaPlayerCardConfig } from "../../MediaPlayerCommon";
+import { MediocreMassiveMediaPlayerCardConfig } from "../../MediaPlayerCommon";
 
 const TitleWrap = styled.div`
   display: flex;
@@ -29,7 +29,9 @@ const TitleH3 = styled.h3`
 
 export const Title = () => {
   const { hass, config } =
-    useContext<CardContextType<MediocreMediaPlayerCardConfig>>(CardContext);
+    useContext<CardContextType<MediocreMassiveMediaPlayerCardConfig>>(
+      CardContext
+    );
   const title = hass.states[config.entity_id].attributes?.media_title;
   const artist = hass.states[config.entity_id].attributes?.media_artist;
   const albumName = hass.states[config.entity_id].attributes?.media_album_name;

--- a/src/components/MediocreMassiveMediaPlayerCard/components/Track.tsx
+++ b/src/components/MediocreMassiveMediaPlayerCard/components/Track.tsx
@@ -2,7 +2,7 @@ import { useContext, useMemo } from "preact/hooks";
 import styled from "@emotion/styled";
 import { ProgressBar } from "../../ProgressBar";
 import { CardContext, CardContextType } from "../../../utils";
-import { MediocreMediaPlayerCardConfig } from "../../MediaPlayerCommon";
+import { MediocreMassiveMediaPlayerCardConfig } from "../../MediaPlayerCommon";
 
 const TrackWrap = styled.div`
   width: 100%;
@@ -17,7 +17,9 @@ const TimeWrap = styled.div`
 
 export const Track = () => {
   const { hass, config } =
-    useContext<CardContextType<MediocreMediaPlayerCardConfig>>(CardContext);
+    useContext<CardContextType<MediocreMassiveMediaPlayerCardConfig>>(
+      CardContext
+    );
   const mediaPosition = useMemo(() => {
     const player = hass.states[config.entity_id];
     const mediaPosition = player.attributes?.media_position ?? null;

--- a/src/components/MediocreMassiveMediaPlayerCard/components/VolumeController.tsx
+++ b/src/components/MediocreMassiveMediaPlayerCard/components/VolumeController.tsx
@@ -3,7 +3,7 @@ import styled from "@emotion/styled";
 import { IconButton } from "../../IconButton";
 import { CardContext, CardContextType } from "../../../utils";
 import { Slider } from "../../Slider";
-import { MediocreMediaPlayerCardConfig } from "../../MediaPlayerCommon";
+import { MediocreMassiveMediaPlayerCardConfig } from "../../MediaPlayerCommon";
 
 const VolumeContainer = styled.div`
   display: flex;
@@ -19,7 +19,9 @@ const ControlButton = styled(IconButton)<{ muted?: boolean }>`
 
 export const VolumeController = () => {
   const { hass, config } =
-    useContext<CardContextType<MediocreMediaPlayerCardConfig>>(CardContext);
+    useContext<CardContextType<MediocreMassiveMediaPlayerCardConfig>>(
+      CardContext
+    );
   const { entity_id } = config;
   const player = hass.states[entity_id];
 
@@ -75,7 +77,9 @@ export const getVolumeIcon = (volume, volumeMuted) => {
 
 export const VolumeTrigger = ({ onClick }: { onClick: () => void }) => {
   const { hass, config } =
-    useContext<CardContextType<MediocreMediaPlayerCardConfig>>(CardContext);
+    useContext<CardContextType<MediocreMassiveMediaPlayerCardConfig>>(
+      CardContext
+    );
   const { entity_id } = config;
   const player = hass.states[entity_id];
 

--- a/src/utils/CardEditorWrapper.tsx
+++ b/src/utils/CardEditorWrapper.tsx
@@ -12,6 +12,7 @@ export type EditorCardProps<T> = {
 export class CardEditorWrapper<T> extends HTMLElement {
   _config: T = null;
   Card: Preact.FunctionComponent<EditorCardProps<T>> = null;
+  extraProps: { [key: string]: any } = {};
   _hass: HomeAssistant = null;
 
   set hass(hass) {
@@ -27,6 +28,7 @@ export class CardEditorWrapper<T> extends HTMLElement {
             config={this._config}
             hass={this._hass}
             rootElement={this}
+            {...this.extraProps}
           />
         </GlanceGuard>
       </EmotionContextProvider>,


### PR DESCRIPTION
Introduce a display mode for the media player card, allowing options for panel, card, or in-card views.

Fix the issue where the bottom bar was not visible when no custom buttons were present.