### PR TITLE
Slight refactor and love for massive action buttons

### DIFF
--- a/src/cards/mediocre-massive-media-player-card.tsx
+++ b/src/cards/mediocre-massive-media-player-card.tsx
@@ -42,5 +42,5 @@ window.customCards.push({
   preview: true,
   description: "A media player card with player grouping support.", // Optional
   documentationURL:
-    "https://developers.home-assistant.io/docs/frontend/custom-ui/custom-card", // Adds a help link in the frontend card editor
+    "https://github.com/antontanderup/mediocre-hass-media-player-cards", // Adds a help link in the frontend card editor
 });

--- a/src/cards/mediocre-media-player-card.tsx
+++ b/src/cards/mediocre-media-player-card.tsx
@@ -50,7 +50,7 @@ window.customCards.push({
   type: "mediocre-media-player-card",
   name: "Mediocre Media Player Card",
   preview: true,
-  description: "A media player card with player grouping support.", // Optional
+  description: "A media player card with player grouping support.",
   documentationURL:
-    "https://developers.home-assistant.io/docs/frontend/custom-ui/custom-card", // Adds a help link in the frontend card editor
+    "https://github.com/antontanderup/mediocre-hass-media-player-cards",
 });

--- a/src/components/MediocreMassiveMediaPlayerCard/components/CustomButtons.tsx
+++ b/src/components/MediocreMassiveMediaPlayerCard/components/CustomButtons.tsx
@@ -1,30 +1,29 @@
 import { useContext } from "preact/hooks";
 import styled from "@emotion/styled";
-import type { MediocreMediaPlayerCardConfig } from "../../MediaPlayerCommon/config";
+import type {
+  MediocreMassiveMediaPlayerCardConfig,
+  MediocreMediaPlayerCardConfig,
+} from "../../MediaPlayerCommon/config";
 import { CardContext, CardContextType } from "../../../utils";
 import { Icon } from "../../Icon";
 import { InteractionConfig } from "../../../types/actionTypes";
 import { Chip } from "../../Chip";
-import { IconButton } from "../../IconButton";
 import { useActionProps } from "../../../hooks";
 
 const CustomButtonsContainer = styled.div`
   display: flex;
   flex-direction: row;
   justify-content: flex-start;
+  gap: 2px;
   overflow-x: auto !important;
   scrollbar-width: none;
   -ms-overflow-style: none;
   ::-webkit-scrollbar {
     display: none;
   }
-  padding-top: 16px;
-  padding-bottom: 16px;
-  border-top: 0.5px solid var(--divider-color, rgba(0, 0, 0, 0.12));
-  gap: 2px;
 `;
 
-const ChipButton = styled(Chip)`
+const ButtonChip = styled(Chip)`
   &:first-child {
     margin-left: 16px;
   }
@@ -35,7 +34,9 @@ const ChipButton = styled(Chip)`
 
 export const CustomButtons = () => {
   const { config } =
-    useContext<CardContextType<MediocreMediaPlayerCardConfig>>(CardContext);
+    useContext<CardContextType<MediocreMassiveMediaPlayerCardConfig>>(
+      CardContext
+    );
 
   const { custom_buttons } = config;
 
@@ -50,9 +51,7 @@ export const CustomButtons = () => {
 
 export const CustomButton = ({
   button,
-  type = "chip",
 }: {
-  type?: "chip" | "icon-button";
   button: InteractionConfig & {
     icon?: string;
     name?: string;
@@ -69,21 +68,12 @@ export const CustomButton = ({
       entity: config.entity_id,
     },
   });
-  if (type === "icon-button") {
-    return (
-      <IconButton
-        icon={button.icon ?? "mdi:dots-vertical"}
-        size={"x-small"}
-        {...actionProps}
-      />
-    );
-  }
 
   return (
-    <ChipButton {...actionProps}>
+    <ButtonChip {...actionProps}>
       {!!icon && <Icon icon={icon} size={"x-small"} />}
       {!!name && <span>{name}</span>}
       {actionProps.renderLongPressIndicator()}
-    </ChipButton>
+    </ButtonChip>
   );
 };

--- a/src/components/MediocreMassiveMediaPlayerCard/components/PlayerActions.tsx
+++ b/src/components/MediocreMassiveMediaPlayerCard/components/PlayerActions.tsx
@@ -3,12 +3,13 @@ import styled from "@emotion/styled";
 import { keyframes } from "@emotion/react";
 import { IconButton } from "../../IconButton";
 import { CardContext, CardContextType } from "../../../utils";
-import { ReactNode } from "preact/compat";
+import { Fragment, ReactNode } from "preact/compat";
 import { VolumeController, VolumeTrigger } from "./VolumeController";
 import { SpeakerGrouping } from "./SpeakerGrouping";
 import { InteractionConfig } from "../../../types";
 import { useActionProps } from "../../../hooks";
 import { MediocreMassiveMediaPlayerCardConfig } from "../../MediaPlayerCommon";
+import { CustomButtons } from "./CustomButtons";
 
 const PlaybackControlsWrap = styled.div`
   background-color: var(--card-background-color);
@@ -67,32 +68,23 @@ const ModalContent = styled.div<{ padding?: string }>`
 `;
 
 export const PlayerActions = () => {
-  const { hass, config, rootElement } =
+  const { hass, config } =
     useContext<CardContextType<MediocreMassiveMediaPlayerCardConfig>>(
       CardContext
     );
 
   const { entity_id, custom_buttons, speaker_group } = config;
 
-  const [selected, setSelected] = useState<"volume" | "speaker-grouping">();
+  const [selected, setSelected] = useState<
+    "volume" | "speaker-grouping" | "custom-buttons"
+  >();
 
   const toggleSelected = useCallback(
-    (key: "volume" | "speaker-grouping") => {
+    (key: "volume" | "speaker-grouping" | "custom-buttons") => {
       setSelected(selected === key ? undefined : key);
     },
     [selected]
   );
-
-  const moreInfoButtonProps = useActionProps({
-    rootElement,
-    hass,
-    actionConfig: {
-      tap_action: {
-        action: "more-info",
-      },
-      entity: entity_id,
-    },
-  });
 
   const onTogglePower = useCallback(() => {
     hass.callService("media_player", "toggle", {
@@ -124,14 +116,26 @@ export const PlayerActions = () => {
           onClick={() => toggleSelected("speaker-grouping")}
         />
       )}
-      <IconButton
-        size="small"
-        {...moreInfoButtonProps}
-        icon="mdi:information"
-      />
-      {custom_buttons?.map((button, index) => (
-        <CustomButton key={index} button={button} />
-      ))}
+      {custom_buttons
+        ?.slice(0, 2)
+        .map((button, index) => <CustomButton key={index} button={button} />)}
+      {custom_buttons?.length > 3 && (
+        <Fragment>
+          <IconButton
+            size="small"
+            icon={"mdi:dots-horizontal"}
+            onClick={() => toggleSelected("custom-buttons")}
+          />
+          <Modal
+            title="Shortcuts"
+            isOpen={selected === "custom-buttons"}
+            onClose={() => setSelected(undefined)}
+            padding="16px 0px 16px 0px"
+          >
+            <CustomButtons />
+          </Modal>
+        </Fragment>
+      )}
       <IconButton size="small" icon={"mdi:power"} onClick={onTogglePower} />
       <VolumeTrigger onClick={() => toggleSelected("volume")} />
     </PlaybackControlsWrap>

--- a/src/components/MediocreMassiveMediaPlayerCard/components/SpeakerGrouping.tsx
+++ b/src/components/MediocreMassiveMediaPlayerCard/components/SpeakerGrouping.tsx
@@ -6,6 +6,7 @@ import { CardContext, CardContextType } from "../../../utils";
 import { Fragment } from "preact/jsx-runtime";
 import { Icon } from "../../Icon";
 import { MediocreMassiveMediaPlayerCardConfig } from "../../MediaPlayerCommon";
+import { Chip } from "../../Chip";
 
 const SpeakerGroupContainer = styled.div`
   display: flex;
@@ -45,6 +46,7 @@ const Chips = styled.div`
   display: flex;
   flex-direction: row;
   justify-content: flex-start;
+  gap: 2px;
   overflow-x: auto !important;
   scrollbar-width: none;
   -ms-overflow-style: none;
@@ -52,24 +54,7 @@ const Chips = styled.div`
     display: none;
   }
 `;
-const Chip = styled.div<{ $loading: boolean }>`
-  display: flex;
-  flex: 1 0 auto;
-  flex-direction: row;
-  height: 32px;
-  font-size: 13px;
-  font-weight: 500;
-  line-height: 32px;
-  padding: 0 12px;
-  border-radius: 16px;
-  color: var(--card-background-color);
-  background-color: var(--primary-text-color);
-  margin-right: 5px;
-  justify-content: space-between;
-  align-items: center;
-  gap: 4px;
-  text-wrap: nowrap;
-  cursor: pointer;
+const SpeakerChip = styled(Chip)<{ $loading: boolean }>`
   opacity: ${props => (props.$loading ? 0.3 : 0.8)};
   &:first-child {
     margin-left: 16px;
@@ -198,7 +183,7 @@ export const SpeakerGrouping = () => {
         {availableSpeakers
           .filter(speaker => !speaker.isGrouped)
           .map(speaker => (
-            <Chip
+            <SpeakerChip
               key={speaker.entity_id}
               $loading={playersLoading.includes(speaker.entity_id)}
               onClick={() =>
@@ -208,7 +193,7 @@ export const SpeakerGrouping = () => {
               {speaker.name}
               {speaker.isGrouped && <Icon size="x-small" icon={"mdi:close"} />}
               {!speaker.isGrouped && <Icon size="x-small" icon={"mdi:plus"} />}
-            </Chip>
+            </SpeakerChip>
           ))}
       </Chips>
     </SpeakerGroupContainer>

--- a/src/components/MediocreMediaPlayerCard/MediocreMediaPlayerCard.tsx
+++ b/src/components/MediocreMediaPlayerCard/MediocreMediaPlayerCard.tsx
@@ -125,13 +125,13 @@ export const MediocreMediaPlayerCard = () => {
       ...artAction,
       entity: config.entity_id,
     },
-    overrideCallback: {
-      onTap: tap_opens_popup
-        ? () => {
+    overrideCallback: tap_opens_popup
+      ? {
+          onTap: () => {
             setIsPopupVisible(true);
-          }
-        : undefined,
-    },
+          },
+        }
+      : {},
   });
 
   const togglePower = useCallback(() => {

--- a/src/components/MediocreMediaPlayerCard/components/MassivePopUp.tsx
+++ b/src/components/MediocreMediaPlayerCard/components/MassivePopUp.tsx
@@ -12,6 +12,7 @@ import styled from "@emotion/styled";
 import { keyframes } from "@emotion/react";
 import { Icon } from "../../Icon";
 import { getDeviceIcon } from "./PlayerInfo";
+import { useActionProps } from "../../../hooks";
 
 const slideUp = keyframes`
   from {
@@ -91,10 +92,7 @@ const Title = styled.h2`
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-`;
-
-const CloseButton = styled(IconButton)`
-  margin-left: auto;
+  margin-right: auto;
 `;
 
 const PopupMediocreMassiveMediaPlayerCard = styled(
@@ -137,6 +135,17 @@ export const MassivePopUp = ({
     };
   }, [config]);
 
+  const moreInfoButtonProps = useActionProps({
+    rootElement,
+    hass,
+    actionConfig: {
+      tap_action: {
+        action: "more-info",
+      },
+      entity: entity_id,
+    },
+  });
+
   if (!visible) {
     return null;
   }
@@ -152,7 +161,12 @@ export const MassivePopUp = ({
               <span> +{groupMembers.length - 1}</span>
             )}
           </Title>
-          <CloseButton
+          <IconButton
+            size="small"
+            {...moreInfoButtonProps}
+            icon="mdi:dots-vertical"
+          />
+          <IconButton
             icon="mdi:close"
             size="small"
             onClick={() => setVisible(false)}

--- a/src/components/MediocreMediaPlayerCard/components/SpeakerGrouping.tsx
+++ b/src/components/MediocreMediaPlayerCard/components/SpeakerGrouping.tsx
@@ -6,6 +6,7 @@ import { IconButton } from "../../IconButton";
 import { CardContext, CardContextType } from "../../../utils";
 import { Fragment } from "preact/jsx-runtime";
 import { Icon } from "../../Icon";
+import { Chip } from "../../Chip";
 
 const SpeakerGroupContainer = styled.div`
   display: flex;
@@ -56,6 +57,7 @@ const VolumeControl = styled.div`
 const Chips = styled.div`
   display: flex;
   flex-direction: row;
+  gap: 2px;
   justify-content: flex-start;
   overflow-x: auto !important;
   scrollbar-width: none;
@@ -64,24 +66,8 @@ const Chips = styled.div`
     display: none;
   }
 `;
-const Chip = styled.div<{ $loading: boolean }>`
-  display: flex;
-  flex: 1 0 auto;
-  flex-direction: row;
-  height: 32px;
-  font-size: 13px;
-  font-weight: 500;
-  line-height: 32px;
-  padding: 0 12px;
-  border-radius: 16px;
-  color: var(--card-background-color);
-  background-color: var(--primary-text-color);
-  margin-right: 5px;
-  justify-content: space-between;
-  align-items: center;
-  gap: 4px;
-  text-wrap: nowrap;
-  cursor: pointer;
+
+const SpeakerChip = styled(Chip)<{ $loading: boolean }>`
   opacity: ${props => (props.$loading ? 0.3 : 0.8)};
   &:first-child {
     margin-left: 16px;
@@ -210,7 +196,7 @@ export const SpeakerGrouping = () => {
         {availableSpeakers
           .filter(speaker => !speaker.isGrouped)
           .map(speaker => (
-            <Chip
+            <SpeakerChip
               key={speaker.entity_id}
               $loading={playersLoading.includes(speaker.entity_id)}
               onClick={() =>
@@ -220,7 +206,7 @@ export const SpeakerGrouping = () => {
               {speaker.name}
               {speaker.isGrouped && <Icon size="x-small" icon={"mdi:close"} />}
               {!speaker.isGrouped && <Icon size="x-small" icon={"mdi:plus"} />}
-            </Chip>
+            </SpeakerChip>
           ))}
       </Chips>
     </SpeakerGroupContainer>

--- a/src/hooks/useActionProps.tsx
+++ b/src/hooks/useActionProps.tsx
@@ -39,80 +39,83 @@ export function useActionProps({
     onDoubleTap?: () => void;
   };
 }) {
-  const buttonProps = useButtonCallbacks({
-    onTap: () => {
-      if (overrideCallback?.onTap) {
-        overrideCallback.onTap();
-        return;
-      }
-      const action = actionConfig?.tap_action;
-      if (!action) return;
-      if (action?.action === "perform-action") {
-        performAction({
-          hass,
-          action: action.perform_action,
-          target: action.target,
-          data: action.data,
-        });
-        return;
-      }
-      handleAction(
-        rootElement,
-        hass,
-        patchAction("tap_action", actionConfig as InteractionConfigLegacy),
-        "tap"
-      );
-    },
-    onLongPress: () => {
-      if (overrideCallback?.onLongPress) {
-        overrideCallback.onLongPress();
-        return;
-      }
-      const action = actionConfig?.hold_action;
-      if (!action) return;
-      if (action?.action === "perform-action") {
-        performAction({
-          hass,
-          action: action.perform_action,
-          target: action.target,
-          data: action.data,
-        });
-        return;
-      }
-      handleAction(
-        rootElement,
-        hass,
-        patchAction("hold_action", actionConfig as InteractionConfigLegacy),
-        "hold"
-      );
-    },
-    onDoubleTap: () => {
-      if (overrideCallback?.onDoubleTap) {
-        overrideCallback.onDoubleTap();
-        return;
-      }
-      const action = actionConfig?.double_tap_action;
-      if (!action) return;
-      if (action?.action === "perform-action") {
-        performAction({
-          hass,
-          action: action.perform_action,
-          target: action.target,
-          data: action.data,
-        });
-        return;
-      }
-      handleAction(
-        rootElement,
-        hass,
-        patchAction(
-          "double_tap_action",
-          actionConfig as InteractionConfigLegacy
-        ),
-        "double_tap"
-      );
-    },
-  });
+  const callbacks = useMemo(
+    () => ({
+      onTap: !!actionConfig?.tap_action
+        ? () => {
+            const action = actionConfig.tap_action;
+            if (action.action === "perform-action") {
+              performAction({
+                hass,
+                action: action.perform_action,
+                target: action.target,
+                data: action.data,
+              });
+              return;
+            }
+            handleAction(
+              rootElement,
+              hass,
+              patchAction(
+                "tap_action",
+                actionConfig as InteractionConfigLegacy
+              ),
+              "tap"
+            );
+          }
+        : undefined,
+      onLongPress: !!actionConfig?.hold_action
+        ? () => {
+            const action = actionConfig.hold_action;
+            if (action.action === "perform-action") {
+              performAction({
+                hass,
+                action: action.perform_action,
+                target: action.target,
+                data: action.data,
+              });
+              return;
+            }
+            handleAction(
+              rootElement,
+              hass,
+              patchAction(
+                "hold_action",
+                actionConfig as InteractionConfigLegacy
+              ),
+              "hold"
+            );
+          }
+        : undefined,
+      onDoubleTap: !!actionConfig?.double_tap_action
+        ? () => {
+            const action = actionConfig.double_tap_action;
+            if (action.action === "perform-action") {
+              performAction({
+                hass,
+                action: action.perform_action,
+                target: action.target,
+                data: action.data,
+              });
+              return;
+            }
+            handleAction(
+              rootElement,
+              hass,
+              patchAction(
+                "double_tap_action",
+                actionConfig as InteractionConfigLegacy
+              ),
+              "double_tap"
+            );
+          }
+        : undefined,
+      ...(overrideCallback ?? {}),
+    }),
+    [actionConfig, overrideCallback]
+  );
+
+  const buttonProps = useButtonCallbacks(callbacks);
 
   return useMemo(() => buttonProps, [buttonProps]);
 }


### PR DESCRIPTION
Clean up boilerplate code, refactor action hooks, and use a single chips component everywhere. Introduce expandable custom buttons in the massive card and add more information toggle to the popup header.