### PR TITLE
Simplify build process for media player card

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,7 +8,8 @@ export default defineConfig({
     lib: {
       name: "MediocreMediaPlayerCard",
       entry: ["src/cards/index.ts"],
-      fileName: format => `mediocre-media-player-card.${format}.js`,
+      fileName: () => `mediocre-hass-media-player-cards.js`,
+      formats: ["umd"],
     },
   },
   define: {


### PR DESCRIPTION
Consolidate the build output to a single file to reduce confusion.