### PR TITLE
Fixes for volume state and massive card title

### DIFF
--- a/src/cards/mediocre-massive-media-player-card.tsx
+++ b/src/cards/mediocre-massive-media-player-card.tsx
@@ -32,7 +32,7 @@ class MediocreMassiveMediaPlayerCardWrapper extends CardWrapper<MediocreMassiveM
       return true;
     }
 
-    if (this.config.speaker_group.entities) {
+    if (this.config.speaker_group?.entities) {
       for (const entity of this.config.speaker_group.entities) {
         if (
           getDidMediaPlayerUpdate(

--- a/src/cards/mediocre-massive-media-player-card.tsx
+++ b/src/cards/mediocre-massive-media-player-card.tsx
@@ -32,6 +32,20 @@ class MediocreMassiveMediaPlayerCardWrapper extends CardWrapper<MediocreMassiveM
       return true;
     }
 
+    if (this.config.speaker_group.entities) {
+      for (const entity of this.config.speaker_group.entities) {
+        if (
+          getDidMediaPlayerUpdate(
+            prevHass.states[entity],
+            hass.states[entity],
+            true
+          )
+        ) {
+          return true;
+        }
+      }
+    }
+
     return false;
   };
 

--- a/src/cards/mediocre-media-player-card.tsx
+++ b/src/cards/mediocre-media-player-card.tsx
@@ -38,6 +38,20 @@ class MediocreMediaPlayerCardWrapper extends CardWrapper<MediocreMediaPlayerCard
       return true;
     }
 
+    if (this.config.speaker_group.entities) {
+      for (const entity of this.config.speaker_group.entities) {
+        if (
+          getDidMediaPlayerUpdate(
+            prevHass.states[entity],
+            hass.states[entity],
+            true
+          )
+        ) {
+          return true;
+        }
+      }
+    }
+
     return false;
   };
 

--- a/src/cards/mediocre-media-player-card.tsx
+++ b/src/cards/mediocre-media-player-card.tsx
@@ -38,7 +38,7 @@ class MediocreMediaPlayerCardWrapper extends CardWrapper<MediocreMediaPlayerCard
       return true;
     }
 
-    if (this.config.speaker_group.entities) {
+    if (this.config.speaker_group?.entities) {
       for (const entity of this.config.speaker_group.entities) {
         if (
           getDidMediaPlayerUpdate(

--- a/src/components/MediocreMassiveMediaPlayerCard/components/AlbumArt.tsx
+++ b/src/components/MediocreMassiveMediaPlayerCard/components/AlbumArt.tsx
@@ -1,6 +1,7 @@
 import styled from "@emotion/styled";
 import { Icon, usePlayer } from "@components";
 import { Fragment } from "preact/jsx-runtime";
+import { useState } from "preact/hooks";
 
 const ImgOuter = styled.div`
   display: flex;
@@ -21,6 +22,7 @@ const ImgWrap = styled.div`
   margin-top: 8px;
   margin-bottom: 8px;
   box-shadow: 0px 0px 8px var(--clear-background-color);
+  font-size: 0; /* Hide any text that might be displayed inside */
 `;
 
 const Img = styled.img`
@@ -28,6 +30,8 @@ const Img = styled.img`
   aspect-ratio: 1;
   object-fit: cover;
   background-color: var(--card-background-color);
+  color: transparent; /* Hide alt text if it shows */
+  text-indent: -10000px; /* Move alt text off-screen */
 `;
 
 const SourceIndicator = styled.div<{ contrastColor?: string }>`
@@ -48,21 +52,32 @@ export const AlbumArt = () => {
   } = player.attributes;
   const state = player.state;
 
+  const [error, setError] = useState(false);
+
   return (
     <ImgOuter>
       <ImgWrap>
         <Fragment>
           <Img
-            src={
-              albumArt ??
-              "data:image/svg+xml;charset=utf8,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20width='400'%20height='400'%20viewBox='0%200%20400%20400'%3E%3Crect%20width='400'%20height='400'%20fill='transparent'/%3E%3C/svg%3E"
-            }
+            src={albumArt}
+            onLoad={() => {
+              setError(false);
+            }}
+            onError={() => {
+              setError(true);
+            }}
             alt={
               !!title && !!artist
                 ? `${title} by ${artist}`
                 : `Source: ${source}`
             }
           />
+          {error && (
+            <Img
+              src="data:image/svg+xml;charset=utf8,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20width='400'%20height='400'%20viewBox='0%200%20400%20400'%3E%3Crect%20width='400'%20height='400'%20fill='transparent'/%3E%3C/svg%3E"
+              alt="Album art fallback"
+            />
+          )}
           <SourceIndicator>
             <Icon size="x-small" icon={getIcon({ source, state })} />
           </SourceIndicator>

--- a/src/components/MediocreMassiveMediaPlayerCard/components/AlbumArt.tsx
+++ b/src/components/MediocreMassiveMediaPlayerCard/components/AlbumArt.tsx
@@ -57,7 +57,11 @@ export const AlbumArt = () => {
               albumArt ??
               "data:image/svg+xml;charset=utf8,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20width='400'%20height='400'%20viewBox='0%200%20400%20400'%3E%3Crect%20width='400'%20height='400'%20fill='transparent'/%3E%3C/svg%3E"
             }
-            alt={`${title} by ${artist}`}
+            alt={
+              !!title && !!artist
+                ? `${title} by ${artist}`
+                : `Source: ${source}`
+            }
           />
           <SourceIndicator>
             <Icon size="x-small" icon={getIcon({ source, state })} />

--- a/src/components/MediocreMassiveMediaPlayerCard/components/Title.tsx
+++ b/src/components/MediocreMassiveMediaPlayerCard/components/Title.tsx
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { usePlayer } from "@components/PlayerContext";
+import { usePlayer } from "@components";
 
 const TitleWrap = styled.div`
   display: flex;
@@ -28,18 +28,26 @@ const TitleH3 = styled.h3`
 `;
 
 export const Title = () => {
-  const player = usePlayer();
-  const title = player.attributes?.media_title;
-  const artist = player.attributes?.media_artist;
-  const albumName = player.attributes?.media_album_name;
-  if (!title && !artist && !albumName) {
+  const {
+    attributes: {
+      media_title: title,
+      media_artist: artist,
+      media_album_name: albumName,
+      source,
+    },
+    state,
+  } = usePlayer();
+  const titleText = title || source;
+
+  if (state === "off") {
     return null;
   }
+
   return (
     <TitleWrap>
-      {!!title && <TitleH2>{title}</TitleH2>}
+      {!!titleText && <TitleH2>{titleText}</TitleH2>}
       {(!!albumName || !!artist) && (
-        <TitleH3>{`${albumName ?? ""} - ${artist ?? ""}`}</TitleH3>
+        <TitleH3>{`${albumName !== title ? `${albumName} - ` : ""}${artist}`}</TitleH3>
       )}
     </TitleWrap>
   );

--- a/src/components/MediocreMediaPlayerCard/components/AlbumArt.tsx
+++ b/src/components/MediocreMediaPlayerCard/components/AlbumArt.tsx
@@ -89,7 +89,14 @@ export const AlbumArt = ({
     >
       {albumArt ? (
         <Fragment>
-          <AlbumArtImage src={albumArt} alt={`${title} by ${artist}`} />
+          <AlbumArtImage
+            src={albumArt}
+            alt={
+              !!title && !!artist
+                ? `${title} by ${artist}`
+                : `Source: ${source}`
+            }
+          />
           <SourceIndicator>
             <Icon size="xx-small" icon={getIcon({ source })} />
           </SourceIndicator>

--- a/src/components/MediocreMediaPlayerCard/components/AlbumArt.tsx
+++ b/src/components/MediocreMediaPlayerCard/components/AlbumArt.tsx
@@ -33,6 +33,8 @@ const AlbumArtImage = styled.img`
   width: 100%;
   height: 100%;
   object-fit: cover;
+  color: transparent; /* Hide alt text if it shows */
+  text-indent: -10000px; /* Move alt text off-screen */
 `;
 
 const NoAlbumArt = styled.div`

--- a/src/utils/getDidMediaPlayerUpdate.ts
+++ b/src/utils/getDidMediaPlayerUpdate.ts
@@ -2,25 +2,33 @@ import { HassEntity } from "home-assistant-js-websocket";
 
 export const getDidMediaPlayerUpdate = (
   prevEntity: HassEntity,
-  entity: HassEntity
+  entity: HassEntity,
+  isGroupMember?: boolean
 ) => {
   // List of keys we want to ignore in comparison
-  const compareKeys = [
-    "state",
-    "attributes.media_duration",
-    "attributes.media_title",
-    "attributes.media_artist",
-    "attributes.media_album_name",
-    "attributes.icon",
-    "attributes.friendly_name",
-    "attributes.entity_picture",
-    "attributes.volume_level",
-    "attributes.is_volume_muted",
-    "attributes.shuffle",
-    "attributes.repeat",
-    "attributes.supported_features",
-    "attributes.group_members",
-  ];
+  const compareKeys = isGroupMember
+    ? [
+        "state",
+        "attributes.volume_level",
+        "attributes.is_volume_muted",
+        "attributes.group_members",
+      ]
+    : [
+        "state",
+        "attributes.media_duration",
+        "attributes.media_title",
+        "attributes.media_artist",
+        "attributes.media_album_name",
+        "attributes.icon",
+        "attributes.friendly_name",
+        "attributes.entity_picture",
+        "attributes.volume_level",
+        "attributes.is_volume_muted",
+        "attributes.shuffle",
+        "attributes.repeat",
+        "attributes.supported_features",
+        "attributes.group_members",
+      ];
 
   // Helper function to get nested property values
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
Enhance the media player card by displaying the source when no title is available, implementing fallback alt text for album art, and ensuring group member volume states update correctly. Fix various edge cases related to album art handling.