### PR TITLE
Various Massive Card fixes regarding artwork

### DIFF
--- a/src/components/MediocreMassiveMediaPlayerCard/MediocreMassiveMediaPlayerCard.tsx
+++ b/src/components/MediocreMassiveMediaPlayerCard/MediocreMassiveMediaPlayerCard.tsx
@@ -16,6 +16,7 @@ const Root = styled.div<{
   display: flex;
   justify-content: center;
   align-items: center;
+  --mmpc-extra-horizontal-padding: 0px;
 
   ${props => props.$artColorVars ?? ""}
   ${props => {
@@ -37,6 +38,10 @@ const Root = styled.div<{
           );
           max-height: calc(100vh - var(--header-height, 16px));
         `;
+      }
+      case "popup": {
+        return `
+          --mmpc-extra-horizontal-padding: 12px;`;
       }
       default: {
         return ``;

--- a/src/components/MediocreMassiveMediaPlayerCard/MediocreMassiveMediaPlayerCard.tsx
+++ b/src/components/MediocreMassiveMediaPlayerCard/MediocreMassiveMediaPlayerCard.tsx
@@ -55,6 +55,7 @@ const Wrap = styled.div<{
   mode: MediocreMassiveMediaPlayerCardConfig["mode"];
 }>`
   display: flex;
+  flex: 1;
   flex-direction: column;
   gap: 16px;
   justify-content: space-around;

--- a/src/components/MediocreMassiveMediaPlayerCard/components/AlbumArt.tsx
+++ b/src/components/MediocreMassiveMediaPlayerCard/components/AlbumArt.tsx
@@ -34,12 +34,29 @@ const Img = styled.img`
   text-indent: -10000px; /* Move alt text off-screen */
 `;
 
-const SourceIndicator = styled.div<{ contrastColor?: string }>`
+const SourceIndicator = styled.div<{ $centered: boolean }>`
   position: absolute;
   bottom: 6px;
   right: 6px;
   --icon-primary-color: var(--art-on-art-color, --primary-text-color);
   opacity: 0.8;
+  ${props => {
+    if (props.$centered) {
+      return `
+        bottom: 0px;
+        right: 0px;
+        width: 100%;
+        height: 100%;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        --icon-primary-color: var(--card-background-color);
+        background-color: var(--primary-text-color);
+        opacity: 0.5;
+        `;
+    }
+    return "";
+  }}
 `;
 
 export const AlbumArt = () => {
@@ -53,33 +70,39 @@ export const AlbumArt = () => {
   const state = player.state;
 
   const [error, setError] = useState(false);
+  const hasAlbumArt = !!albumArt && !error;
 
   return (
     <ImgOuter>
       <ImgWrap>
         <Fragment>
-          <Img
-            src={albumArt}
-            onLoad={() => {
-              setError(false);
-            }}
-            onError={() => {
-              setError(true);
-            }}
-            alt={
-              !!title && !!artist
-                ? `${title} by ${artist}`
-                : `Source: ${source}`
-            }
-          />
-          {error && (
+          {!!albumArt && (
+            <Img
+              src={albumArt}
+              onLoad={() => {
+                setError(false);
+              }}
+              onError={() => {
+                setError(true);
+              }}
+              alt={
+                !!title && !!artist
+                  ? `${title} by ${artist}`
+                  : `Source: ${source}`
+              }
+            />
+          )}
+          {!hasAlbumArt && (
             <Img
               src="data:image/svg+xml;charset=utf8,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20width='400'%20height='400'%20viewBox='0%200%20400%20400'%3E%3Crect%20width='400'%20height='400'%20fill='transparent'/%3E%3C/svg%3E"
               alt="Album art fallback"
             />
           )}
-          <SourceIndicator>
-            <Icon size="x-small" icon={getIcon({ source, state })} />
+          <SourceIndicator $centered={!hasAlbumArt}>
+            <Icon
+              size={!hasAlbumArt ? "x-large" : "x-small"}
+              icon={getIcon({ source, state })}
+            />
           </SourceIndicator>
         </Fragment>
       </ImgWrap>

--- a/src/components/MediocreMassiveMediaPlayerCard/components/AlbumArt.tsx
+++ b/src/components/MediocreMassiveMediaPlayerCard/components/AlbumArt.tsx
@@ -21,7 +21,6 @@ const ImgWrap = styled.div`
   align-self: center;
   margin-top: 8px;
   margin-bottom: 8px;
-  box-shadow: 0px 0px 8px var(--clear-background-color);
   font-size: 0; /* Hide any text that might be displayed inside */
 `;
 

--- a/src/components/MediocreMassiveMediaPlayerCard/components/PlaybackControls.tsx
+++ b/src/components/MediocreMassiveMediaPlayerCard/components/PlaybackControls.tsx
@@ -12,6 +12,8 @@ const PlaybackControlsWrap = styled.div`
   align-items: center;
   justify-content: space-around;
   width: 100%;
+  padding-left: var(--mmpc-extra-horizontal-padding, 0px);
+  padding-right: var(--mmpc-extra-horizontal-padding, 0px);
 `;
 
 export const PlaybackControls = () => {

--- a/src/components/MediocreMassiveMediaPlayerCard/components/Title.tsx
+++ b/src/components/MediocreMassiveMediaPlayerCard/components/Title.tsx
@@ -8,6 +8,8 @@ const TitleWrap = styled.div`
   gap: 8px;
   text-align: center;
   color: var(--primary-text-color, #fff);
+  padding-left: var(--mmpc-extra-horizontal-padding, 0px);
+  padding-right: var(--mmpc-extra-horizontal-padding, 0px);
   > h2,
   > h3 {
     overflow: hidden;

--- a/src/components/MediocreMassiveMediaPlayerCard/components/Track.tsx
+++ b/src/components/MediocreMassiveMediaPlayerCard/components/Track.tsx
@@ -2,6 +2,11 @@ import { useMemo, useEffect, useState } from "preact/hooks";
 import styled from "@emotion/styled";
 import { ProgressBar, usePlayer } from "@components";
 
+const TrackWrap = styled.div`
+  padding-left: var(--mmpc-extra-horizontal-padding, 0px);
+  padding-right: var(--mmpc-extra-horizontal-padding, 0px);
+`;
+
 const TimeWrap = styled.div`
   display: flex;
   flex-direction: row;
@@ -69,7 +74,7 @@ export const Track = () => {
   }
 
   return (
-    <div>
+    <TrackWrap>
       <ProgressBar
         value={position.currentPosition}
         min={0}
@@ -79,6 +84,6 @@ export const Track = () => {
         <span>{position.prettyNow}</span>
         <span>{position.prettyEnd}</span>
       </TimeWrap>
-    </div>
+    </TrackWrap>
   );
 };


### PR DESCRIPTION
Fix too narrow controls in no or narrow artwork situations.
Provide better fallbacks when no art or errored art.
Remove shadow on art.
Add a little extra padding on elements when in popup.