### PR TITLE
Fix MA source issue and add shared title and subtitle logic

### DIFF
--- a/src/components/MediocreMassiveMediaPlayerCard/components/Title.tsx
+++ b/src/components/MediocreMassiveMediaPlayerCard/components/Title.tsx
@@ -30,27 +30,12 @@ const TitleH3 = styled.h3`
 `;
 
 export const Title = () => {
-  const {
-    attributes: {
-      media_title: title,
-      media_artist: artist,
-      media_album_name: albumName,
-      source,
-    },
-    state,
-  } = usePlayer();
-  const titleText = title || source;
-
-  if (state === "off") {
-    return null;
-  }
+  const { title, subtitle } = usePlayer();
 
   return (
     <TitleWrap>
-      {!!titleText && <TitleH2>{titleText}</TitleH2>}
-      {(!!albumName || !!artist) && (
-        <TitleH3>{`${albumName !== title ? `${albumName} - ` : ""}${artist}`}</TitleH3>
-      )}
+      {!!title && <TitleH2>{title}</TitleH2>}
+      {!!subtitle && <TitleH3>{subtitle}</TitleH3>}
     </TitleWrap>
   );
 };

--- a/src/components/MediocreMediaPlayerCard/MediocreMediaPlayerCard.tsx
+++ b/src/components/MediocreMediaPlayerCard/MediocreMediaPlayerCard.tsx
@@ -95,14 +95,7 @@ export const MediocreMediaPlayerCard = () => {
 
   const { artVars, haVars } = useArtworkColors();
 
-  const {
-    state,
-    attributes: {
-      media_title: title,
-      media_artist: artist,
-      media_album_name: albumName,
-    },
-  } = usePlayer();
+  const { state, subtitle } = usePlayer();
 
   const supportedFeatures = useSupportedFeatures();
   const hasNoPlaybackControls =
@@ -127,8 +120,7 @@ export const MediocreMediaPlayerCard = () => {
 
   const [isPopupVisible, setIsPopupVisible] = useState(false);
 
-  const artSize =
-    state === "off" || (!title && !artist && !albumName) ? 68 : 100;
+  const artSize = state === "off" || !subtitle ? 68 : 100;
 
   const artAction: InteractionConfig = action ?? {
     tap_action: { action: "more-info" },

--- a/src/components/MediocreMediaPlayerCard/components/MetaInfo.tsx
+++ b/src/components/MediocreMediaPlayerCard/components/MetaInfo.tsx
@@ -22,22 +22,12 @@ const ArtistText = styled.p`
 `;
 
 export const MetaInfo = () => {
-  const {
-    attributes: {
-      media_title: title,
-      media_artist: artist,
-      media_album_name: albumName,
-      source,
-      friendly_name: friendlyName,
-    },
-  } = usePlayer();
-  const titleText = title ?? source ?? friendlyName;
-  const artistText = `${albumName !== title ? `${albumName} - ` : ""}${artist}`;
+  const { title, subtitle } = usePlayer();
 
   return (
     <Fragment>
-      {!!titleText && <TitleText>{titleText}</TitleText>}
-      {(!!albumName || !!artist) && <ArtistText>{artistText}</ArtistText>}
+      {!!title && <TitleText>{title}</TitleText>}
+      {!!subtitle && <ArtistText>{subtitle}</ArtistText>}
     </Fragment>
   );
 };


### PR DESCRIPTION
Resolve an issue with the media source (MA returning an entity_id) and implement a unified approach for handling titles and subtitles across components.
Simplifies things a tiny bit.