### PR TITLE
Specify player unavailable status

### DIFF
--- a/src/components/PlayerContext/PlayerContext.tsx
+++ b/src/components/PlayerContext/PlayerContext.tsx
@@ -49,6 +49,16 @@ export const PlayerContextProvider = ({
       };
     }
 
+    if (state === "unavailable") {
+      return {
+        player: {
+          ...player,
+          title: "Unavailable",
+          subtitle: `${entityId} unavailable`,
+        },
+      };
+    }
+
     let title = mediaTitle;
     if (!title || title === "") {
       if (


### PR DESCRIPTION
Clearly indicate when a player is unavailable by updating the player context with a specific title and subtitle.