### PR TITLE
Use content type as the main filter in standard search

### DIFF
--- a/src/components/HaSearch/HaSearch.tsx
+++ b/src/components/HaSearch/HaSearch.tsx
@@ -1,5 +1,5 @@
 import { Chip, Input, MediaTrack } from "@components";
-import { useCallback, useMemo, useState } from "preact/hooks";
+import { useCallback, useState } from "preact/hooks";
 import { useDebounce } from "@uidotdev/usehooks";
 import {
   MediaItem,
@@ -7,39 +7,29 @@ import {
   searchStyles,
 } from "@components/MediaSearch";
 import {
-  HaMediaClass,
   HaFilterConfig,
   HaEnqueueMode,
   HaFilterType,
-  HaMediaItem,
+  HaContentType,
+  HaFilterResult,
 } from "./types";
 import { useSearchQuery } from "./useSearchQuery";
 import { Fragment } from "preact";
 
 const filters: HaFilterConfig[] = [
   { type: "all", label: "All", icon: "mdi:all-inclusive" },
-  { type: "artist", label: "Artists", icon: "mdi:account-music" },
-  { type: "album", label: "Albums", icon: "mdi:album" },
-  { type: "track", label: "Tracks", icon: "mdi:music-note" },
-  { type: "playlist", label: "Playlists", icon: "mdi:playlist-music" },
-  { type: "podcast", label: "Podcasts", icon: "mdi:podcast" },
+  { type: "artists", label: "Artists", icon: "mdi:account-music" },
+  { type: "albums", label: "Albums", icon: "mdi:album" },
+  { type: "tracks", label: "Tracks", icon: "mdi:music-note" },
+  { type: "playlists", label: "Playlists", icon: "mdi:playlist-music" },
 ];
 
-const responseKeyMediaTypeMap: { [key: string]: HaMediaClass } = {
-  artists: "artist",
-  albums: "album",
-  tracks: "track",
-  playlists: "playlist",
-  podcasts: "podcast",
-};
-
-const labelMap: { [key in HaMediaClass]: string } = {
-  artist: "Artists",
+const labelMap: { [key in HaContentType]: string } = {
+  artists: "Artists",
+  albums: "Albums",
+  tracks: "Tracks",
+  playlists: "Playlists",
   music: "Music",
-  album: "Albums",
-  track: "Tracks",
-  playlist: "Playlists",
-  podcast: "Podcasts",
 };
 
 export type HaSearchProps = {
@@ -117,21 +107,22 @@ export const HaSearch = ({
     ));
   };
 
-  const renderResult = (result: HaMediaItem[], mediaType: HaMediaClass) => {
+  const renderResult = (result: HaFilterResult[number]) => {
     if (!result) return null;
+    const { type: mediaType, results } = result;
     if (activeFilter !== "all" && activeFilter !== mediaType) return null;
-    if (result.length === 0 && activeFilter === "all") return null;
+    if (results.length === 0 && activeFilter === "all") return null;
 
     return (
       <Fragment key={mediaType}>
         {activeFilter === "all" && (
-          <MediaSectionTitle onClick={() => setActiveFilter(mediaType)}>
+          <MediaSectionTitle onClick={() => setActiveFilter("all")}>
             {labelMap[mediaType]}
           </MediaSectionTitle>
         )}
-        {mediaType === "track" ? (
+        {mediaType === "tracks" ? (
           <div css={searchStyles.trackListContainer}>
-            {(activeFilter === "all" ? result.slice(0, 5) : result).map(
+            {(activeFilter === "all" ? results.slice(0, 5) : results).map(
               item => (
                 <MediaTrack
                   key={item.media_content_id}
@@ -144,7 +135,7 @@ export const HaSearch = ({
           </div>
         ) : (
           <div css={searchStyles.mediaGrid}>
-            {(activeFilter === "all" ? result.slice(0, 6) : result).map(
+            {(activeFilter === "all" ? results.slice(0, 6) : results).map(
               item => (
                 <MediaItem
                   key={item.media_content_id}
@@ -156,7 +147,7 @@ export const HaSearch = ({
             )}
           </div>
         )}
-        {result.length === 0 && (
+        {results.length === 0 && (
           <p css={searchStyles.mediaEmptyText}>
             {loading ? "Searching..." : "No results found."}
           </p>
@@ -164,18 +155,6 @@ export const HaSearch = ({
       </Fragment>
     );
   };
-
-  const sortedResults = useMemo(() => {
-    if (!results) return null;
-    const sorted: { [key: string]: HaMediaItem[] } = {
-      artists: results.result.filter(item => item.media_class === "artist"),
-      albums: results.result.filter(item => item.media_class === "album"),
-      tracks: results.result.filter(item => item.media_class === "track"),
-      playlists: results.result.filter(item => item.media_class === "playlist"),
-      podcasts: results.result.filter(item => item.media_class === "podcast"),
-    };
-    return sorted;
-  }, [results]);
 
   return (
     <div
@@ -196,9 +175,7 @@ export const HaSearch = ({
               : {}
           }
         >
-          {Object.entries(sortedResults).map(([key, value]) => {
-            return renderResult(value, responseKeyMediaTypeMap[key]);
-          })}
+          {results.map(renderResult)}
         </div>
       )}
       {error && (

--- a/src/components/HaSearch/types.ts
+++ b/src/components/HaSearch/types.ts
@@ -8,10 +8,14 @@ export type HaMediaClass =
   | "podcast";
 
 // Filter types (includes "all" in addition to HaMediaClass)
-export type HaFilterType = "all" | HaMediaClass;
+export type HaFilterType = "all" | HaContentType;
 
-export type HaContentType = //image, music, tv show, video, episode, channel, or playlist
-  "image" | "music" | "tv_show" | "video" | "episode" | "channel" | "playlist";
+export type HaContentType =
+  | "tracks"
+  | "albums"
+  | "artists"
+  | "playlists"
+  | "music";
 
 // Enqueue modes for media playback
 export type HaEnqueueMode = "add" | "next" | "play" | "replace";
@@ -23,6 +27,10 @@ export interface HaFilterConfig {
   icon: string;
 }
 
+export type HaFilterResult = (HaFilterConfig & {
+  results: HaMediaItem[];
+})[];
+
 // Base media item interface
 export interface HaMediaItem {
   media_class: HaMediaClass;
@@ -30,6 +38,8 @@ export interface HaMediaItem {
   media_content_type: HaContentType;
   title: string;
   can_play: boolean;
+  can_expand: boolean;
+  can_search: boolean;
   thumbnail: string | null;
 }
 

--- a/src/components/HaSearch/useSearchQuery.ts
+++ b/src/components/HaSearch/useSearchQuery.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from "preact/hooks";
 import { getHass } from "@utils";
 import {
   HaEnqueueMode,
+  HaFilterResult,
   HaFilterType,
   HaMediaItem,
   HaSearchResponse,
@@ -26,7 +27,7 @@ export const useSearchQuery = (
       service_data: {
         search_query: debounceQuery,
         entity_id: targetEntity,
-        media_filter_classes: filter === "all" ? undefined : [filter],
+        media_content_type: filter === "all" ? undefined : filter,
       },
       return_response: true,
     };
@@ -65,8 +66,57 @@ export const useSearchQuery = (
     []
   );
 
+  const resultsParsed: HaFilterResult = useMemo(() => {
+    return [
+      {
+        type: "artists",
+        label: "Artists",
+        icon: "mdi:account-music",
+        results:
+          results?.result.filter(
+            item =>
+              item.media_content_type === "artists" ||
+              item.media_class === "artist"
+          ) ?? [],
+      },
+      {
+        type: "albums",
+        label: "Albums",
+        icon: "mdi:album",
+        results:
+          results?.result.filter(
+            item =>
+              item.media_content_type === "albums" ||
+              item.media_class === "album"
+          ) ?? [],
+      },
+      {
+        type: "tracks",
+        label: "Tracks",
+        icon: "mdi:music-note",
+        results:
+          results?.result.filter(
+            item =>
+              item.media_content_type === "tracks" ||
+              item.media_class === "track"
+          ) ?? [],
+      },
+      {
+        type: "playlists",
+        label: "Playlists",
+        icon: "mdi:playlist-music",
+        results:
+          results?.result.filter(
+            item =>
+              item.media_content_type === "playlists" ||
+              item.media_class === "playlist"
+          ) ?? [],
+      },
+    ];
+  }, [results]);
+
   return useMemo(
-    () => ({ results, loading, playItem, error }),
+    () => ({ results: resultsParsed, loading, playItem, error }),
     [results, loading, error]
   );
 };


### PR DESCRIPTION
Replace the class-based filtering with content type. Resolves #65 .