### PR TITLE
feat: add music assistant queue display

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 <img src="https://github.com/user-attachments/assets/2ba5d55d-6fd3-4508-ae1c-60d9f22ebe81" width="500px" alt="Mediocre Media Player Card Screenshot 1" />
 
-Media player cards for Home Assistant that let you group speakers, add custom action buttons, search for music and more. A visual editor is available for all media player card configuration options.
+Media player cards for Home Assistant that let you group speakers, add custom action buttons, search for music, view queues and more. A visual editor is available for all media player card configuration options.
 
 > **Note:** This is a pretty new project, so you might encounter some bugs. If you do, please do report them.
 
@@ -48,7 +48,7 @@ resources:
 
 ### Mediocre Media Player Card
 
-A standard-sized media player card. Supports grouping speakers (including volume management), custom action buttons, and search (when used with Music Assistant).
+A standard-sized media player card. Supports grouping speakers (including volume management), custom action buttons, and search and queue (when used with Music Assistant).
 
 <img src="https://github.com/user-attachments/assets/a4ad8f2c-aafe-424f-9626-ff3353cbd605" width="500px" alt="Mediocre Media Player Card Screenshot 2" />
 
@@ -66,7 +66,7 @@ speaker_group:
 
 ### Mediocre Massive Media Player Card
 
-A full-sized media player card. Just like the regular card it supports grouping speakers (including volume management), custom action buttons, and search (when used with Music Assistant). In fact they share most of the configuration options.
+A full-sized media player card. Just like the regular card it supports grouping speakers (including volume management), custom action buttons, and search and queue (when used with Music Assistant). In fact they share most of the configuration options.
 
 <img src="https://github.com/user-attachments/assets/793f9b8f-032b-4309-b8ef-1f38935e448a" width="500px" alt="Mediocre Massive Media Player Card Screenshot" />
 
@@ -94,7 +94,7 @@ Both cards support these options:
 | `speaker_group.entity_id` | string | -        | Entity ID of the main speaker if different from the media player |
 | `speaker_group.entities`  | array  | -        | List of entity IDs that can be grouped with the main speaker     |
 | `custom_buttons`          | array  | -        | List of custom buttons to display                                |
-| `ma_entity_id`            | string | -        | Music Assistant entity id (adds search)                          |
+| `ma_entity_id`            | string | -        | Music Assistant entity id (adds search & queue features)         |
 | `ma_favorite_button_entity_id` | string | - | Music Assistant favorite button entity (shows a heart-plus button to mark the current song as favorite) |
 | `options`                 | object | -        | Additional display options for fine-tuning the card              |
 | `options.always_show_power_button` | boolean | `false` | Always show the power button, even if the media player is on |
@@ -192,10 +192,15 @@ entities:
 
 Both the Mediocre Media Player Card and the Mediocre Massive Media Player Card support search functionality. By specifying a `ma_entity_id`, you can enable Music Assistant-specific search features directly within the card. Alternatively, enabling the `search.enabled` option will use the regular Home Assistant `search_media` functionality. Read more about configuring the cards for search [here](./docs/README_SEARCH.md).
 
+## Queue Functionality
+
+When a `ma_entity_id` is specified and `queue.enabled` is set to `true`, the cards can display the current playback queue from Music Assistant. Read more about configuring the cards for queue support [here](./docs/README_QUEUE.md).
+
 ## Additional Documentation
 
 - [Using Universal Media Player with Mediocre Media Player Cards](./docs/README_UMP.md)
 - [Search Functionality with Mediocre Media Player Cards](./docs/README_SEARCH.md)
+- [Queue Functionality with Mediocre Media Player Cards](./docs/README_QUEUE.md)
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # 🎵 Mediocre Media Player Cards
+
 [![hacs_badge](https://img.shields.io/badge/HACS-Custom-orange.svg)](https://github.com/custom-components/hacs)
 [![GitHub Release](https://img.shields.io/github/v/release/antontanderup/mediocre-hass-media-player-cards?color=blue)](https://github.com/antontanderup/mediocre-hass-media-player-cards/releases)
 [![GitHub Downloads (all assets, all releases)](https://img.shields.io/github/downloads/antontanderup/mediocre-hass-media-player-cards/total)](https://github.com/antontanderup/mediocre-hass-media-player-cards/releases)
-[![Chat on Oase](https://img.shields.io/badge/Chat-Oase-lightblue?color=rgb(74%20196%20169))](https://oase.app/oase/8414e128-52fe-42c7-b7c8-789fd0930a3e/join/cfdc211d-eb53-4cef-af62-2d1c4642a180)
+[![Chat on Oase](<https://img.shields.io/badge/Chat-Oase-lightblue?color=rgb(74%20196%20169)>)](https://oase.app/oase/8414e128-52fe-42c7-b7c8-789fd0930a3e/join/cfdc211d-eb53-4cef-af62-2d1c4642a180)
 <br/>
 
 <img src="https://github.com/user-attachments/assets/2ba5d55d-6fd3-4508-ae1c-60d9f22ebe81" width="500px" alt="Mediocre Media Player Card Screenshot 1" />
@@ -86,25 +87,25 @@ speaker_group:
 
 Both cards support these options:
 
-| Option                    | Type   | Default  | Description                                                      |
-| ------------------------- | ------ | -------- | ---------------------------------------------------------------- |
-| `entity_id`               | string | Required | The entity ID of the media player                                |
-| `action`                  | object | -        | Configuration for tap actions                                    |
-| `speaker_group`           | object | -        | Configuration for speaker grouping                               |
-| `speaker_group.entity_id` | string | -        | Entity ID of the main speaker if different from the media player |
-| `speaker_group.entities`  | array  | -        | List of entity IDs that can be grouped with the main speaker     |
-| `custom_buttons`          | array  | -        | List of custom buttons to display                                |
-| `ma_entity_id`            | string | -        | Music Assistant entity id (adds search & queue features)         |
-| `ma_favorite_button_entity_id` | string | - | Music Assistant favorite button entity (shows a heart-plus button to mark the current song as favorite) |
-| `options`                 | object | -        | Additional display options for fine-tuning the card              |
-| `options.always_show_power_button` | boolean | `false` | Always show the power button, even if the media player is on |
+| Option                             | Type    | Default  | Description                                                                                             |
+| ---------------------------------- | ------- | -------- | ------------------------------------------------------------------------------------------------------- |
+| `entity_id`                        | string  | Required | The entity ID of the media player                                                                       |
+| `action`                           | object  | -        | Configuration for tap actions                                                                           |
+| `speaker_group`                    | object  | -        | Configuration for speaker grouping                                                                      |
+| `speaker_group.entity_id`          | string  | -        | Entity ID of the main speaker if different from the media player                                        |
+| `speaker_group.entities`           | array   | -        | List of entity IDs that can be grouped with the main speaker                                            |
+| `custom_buttons`                   | array   | -        | List of custom buttons to display                                                                       |
+| `ma_entity_id`                     | string  | -        | Music Assistant entity id (adds search & queue features)                                                |
+| `ma_favorite_button_entity_id`     | string  | -        | Music Assistant favorite button entity (shows a heart-plus button to mark the current song as favorite) |
+| `options`                          | object  | -        | Additional display options for fine-tuning the card                                                     |
+| `options.always_show_power_button` | boolean | `false`  | Always show the power button, even if the media player is on                                            |
 
 The Mediocre Media Player Card has additional options:
 
-| Option            | Type    | Default | Description                                                            |
-| ----------------- | ------- | ------- | ---------------------------------------------------------------------- |
-| `tap_opens_popup` | boolean | `false` | When set to true, tapping the card opens a popup with the massive card |
-| `options.always_show_custom_buttons` | boolean | `false` | Always show custom buttons panel expanded |
+| Option                               | Type    | Default | Description                                                            |
+| ------------------------------------ | ------- | ------- | ---------------------------------------------------------------------- |
+| `tap_opens_popup`                    | boolean | `false` | When set to true, tapping the card opens a popup with the massive card |
+| `options.always_show_custom_buttons` | boolean | `false` | Always show custom buttons panel expanded                              |
 
 The Mediocre Massive Media Player Card has additional options:
 
@@ -152,7 +153,6 @@ Both the Mediocre Media Player Card and the Mediocre Massive Media Player Card s
 
 ### Configuration
 
-
 ```yaml
 type: "custom:mediocre-media-player-card"
 entity_id: media_player.living_room_musiccast
@@ -194,7 +194,7 @@ Both the Mediocre Media Player Card and the Mediocre Massive Media Player Card s
 
 ## Queue Functionality
 
-When a `ma_entity_id` is specified and `queue.enabled` is set to `true`, the cards can display the current playback queue from Music Assistant. Read more about configuring the cards for queue support [here](./docs/README_QUEUE.md).
+To display the queue, the cards rely on the [`mass_queue`](https://github.com/droans/mass_queue) custom component for Home Assistant. Install this component in your Home Assistant instance before enabling the queue feature. Once installed, and with a `ma_entity_id` specified and `queue.enabled` set to `true`, the cards can show the current playback queue from Music Assistant. Read more about configuring the cards for queue support [here](./docs/README_QUEUE.md).
 
 ## Additional Documentation
 

--- a/docs/README_QUEUE.md
+++ b/docs/README_QUEUE.md
@@ -1,6 +1,6 @@
 # Queue Functionality with Mediocre Media Player Cards
 
-The Mediocre Media Player Cards can display the current playback queue when used with Music Assistant.
+The Mediocre Media Player Cards can display the current playback queue when used with Music Assistant. To enable this feature, first install the [`mass_queue`](https://github.com/droans/mass_queue) custom component for Home Assistant, which exposes Music Assistant's queue to Home Assistant.
 
 ## Configuration Example
 
@@ -20,4 +20,3 @@ queue:
 - `queue.enabled`: Set to `true` to show the current queue in the card.
 
 Once configured, the card will display a queue button that opens the list of upcoming items, similar to the search interface.
-

--- a/docs/README_QUEUE.md
+++ b/docs/README_QUEUE.md
@@ -1,0 +1,23 @@
+# Queue Functionality with Mediocre Media Player Cards
+
+The Mediocre Media Player Cards can display the current playback queue when used with Music Assistant.
+
+## Configuration Example
+
+To enable the queue, specify a `ma_entity_id` and set `queue.enabled` to `true`:
+
+```yaml
+type: "custom:mediocre-media-player-card"
+entity_id: media_player.living_room
+ma_entity_id: media_player.living_room_ma
+queue:
+  enabled: true
+```
+
+### Explanation
+
+- `ma_entity_id`: Music Assistant entity ID. Required for accessing the queue.
+- `queue.enabled`: Set to `true` to show the current queue in the card.
+
+Once configured, the card will display a queue button that opens the list of upcoming items, similar to the search interface.
+

--- a/src/components/MaQueue/MaQueue.tsx
+++ b/src/components/MaQueue/MaQueue.tsx
@@ -1,0 +1,55 @@
+import { css } from "@emotion/react";
+import { searchStyles } from "@components/MediaSearch";
+import { MediaTrack, Spinner } from "@components";
+import { useQueue } from "./useQueue";
+
+export type MaQueueProps = {
+  entityId: string;
+  horizontalPadding?: number;
+  maxHeight?: number;
+};
+
+const styles = {
+  container: (horizontalPadding: number) =>
+    css({
+      "--mmpc-search-padding": `${horizontalPadding}px`,
+    }),
+};
+
+export const MaQueue = ({
+  entityId,
+  horizontalPadding = 0,
+  maxHeight = 300,
+}: MaQueueProps) => {
+  const { queue, loading } = useQueue(entityId);
+
+  if (loading) {
+    return <Spinner />;
+  }
+
+  if (!queue || queue.items.length === 0) {
+    return <p css={searchStyles.mediaEmptyText}>Queue is empty</p>;
+  }
+
+  return (
+    <div
+      css={[searchStyles.root, styles.container(horizontalPadding)]}
+      style={{ maxHeight }}
+    >
+      <div css={searchStyles.resultsContainerSearchBarBottom}>
+        {queue.items.map(item => (
+          <MediaTrack
+            key={item.queue_item_id}
+            imageUrl={item.media_item.image ?? item.media_item.album?.image}
+            title={item.media_item.name}
+            artist={item.media_item.artists
+              ?.map(artist => artist.name)
+              .join(", ")}
+            onClick={async () => {}}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+

--- a/src/components/MaQueue/MaQueue.tsx
+++ b/src/components/MaQueue/MaQueue.tsx
@@ -27,7 +27,7 @@ export const MaQueue = ({
     return <Spinner />;
   }
 
-  if (!queue || queue.items.length === 0) {
+  if (!queue || queue.items?.length === 0) {
     return <p css={searchStyles.mediaEmptyText}>Queue is empty</p>;
   }
 
@@ -37,7 +37,7 @@ export const MaQueue = ({
       style={{ maxHeight }}
     >
       <div css={searchStyles.resultsContainerSearchBarBottom}>
-        {queue.items.map(item => (
+        {(queue.items ?? []).map(item => (
           <MediaTrack
             key={item.queue_item_id}
             imageUrl={item.media_item.image ?? item.media_item.album?.image}

--- a/src/components/MaQueue/MaQueue.tsx
+++ b/src/components/MaQueue/MaQueue.tsx
@@ -1,6 +1,6 @@
 import { css } from "@emotion/react";
 import { searchStyles } from "@components/MediaSearch";
-import { MediaTrack, Spinner } from "@components";
+import { IconButton, MediaTrack, Spinner } from "@components";
 import { useQueue } from "./useQueue";
 
 export type MaQueueProps = {
@@ -14,6 +14,10 @@ const styles = {
     css({
       "--mmpc-search-padding": `${horizontalPadding}px`,
     }),
+  actions: css({
+    display: "flex",
+    gap: 4,
+  }),
 };
 
 export const MaQueue = ({
@@ -21,7 +25,15 @@ export const MaQueue = ({
   horizontalPadding = 0,
   maxHeight = 300,
 }: MaQueueProps) => {
-  const { queue, loading } = useQueue(entityId);
+  const {
+    queue,
+    loading,
+    removeQueueItem,
+    playQueueItem,
+    moveQueueItemUp,
+    moveQueueItemDown,
+    moveQueueItemNext,
+  } = useQueue(entityId);
 
   if (loading) {
     return <Spinner />;
@@ -43,11 +55,53 @@ export const MaQueue = ({
             imageUrl={item.media_image}
             title={item.media_title}
             artist={item.media_artist}
-            onClick={async () => {}}
+            actions={
+              <div css={styles.actions}>
+                <IconButton
+                  size="xx-small"
+                  icon="mdi:play"
+                  onClick={async e => {
+                    e.stopPropagation();
+                    await playQueueItem(item.queue_item_id);
+                  }}
+                />
+                <IconButton
+                  size="xx-small"
+                  icon="mdi:arrow-up"
+                  onClick={async e => {
+                    e.stopPropagation();
+                    await moveQueueItemUp(item.queue_item_id);
+                  }}
+                />
+                <IconButton
+                  size="xx-small"
+                  icon="mdi:arrow-down"
+                  onClick={async e => {
+                    e.stopPropagation();
+                    await moveQueueItemDown(item.queue_item_id);
+                  }}
+                />
+                <IconButton
+                  size="xx-small"
+                  icon="mdi:skip-next"
+                  onClick={async e => {
+                    e.stopPropagation();
+                    await moveQueueItemNext(item.queue_item_id);
+                  }}
+                />
+                <IconButton
+                  size="xx-small"
+                  icon="mdi:close"
+                  onClick={async e => {
+                    e.stopPropagation();
+                    await removeQueueItem(item.queue_item_id);
+                  }}
+                />
+              </div>
+            }
           />
         ))}
       </div>
     </div>
   );
 };
-

--- a/src/components/MaQueue/MaQueue.tsx
+++ b/src/components/MaQueue/MaQueue.tsx
@@ -27,7 +27,7 @@ export const MaQueue = ({
     return <Spinner />;
   }
 
-  if (!queue || queue.items?.length === 0) {
+  if (queue.length === 0) {
     return <p css={searchStyles.mediaEmptyText}>Queue is empty</p>;
   }
 
@@ -37,14 +37,12 @@ export const MaQueue = ({
       style={{ maxHeight }}
     >
       <div css={searchStyles.resultsContainerSearchBarBottom}>
-        {(queue.items ?? []).map(item => (
+        {queue.map(item => (
           <MediaTrack
             key={item.queue_item_id}
-            imageUrl={item.media_item.image ?? item.media_item.album?.image}
-            title={item.media_item.name}
-            artist={item.media_item.artists
-              ?.map(artist => artist.name)
-              .join(", ")}
+            imageUrl={item.media_image}
+            title={item.media_title}
+            artist={item.media_artist}
             onClick={async () => {}}
           />
         ))}

--- a/src/components/MaQueue/index.ts
+++ b/src/components/MaQueue/index.ts
@@ -1,0 +1,2 @@
+export * from "./MaQueue";
+

--- a/src/components/MaQueue/index.ts
+++ b/src/components/MaQueue/index.ts
@@ -1,2 +1,1 @@
 export * from "./MaQueue";
-

--- a/src/components/MaQueue/types.ts
+++ b/src/components/MaQueue/types.ts
@@ -8,4 +8,3 @@ export interface MaQueueItem {
 }
 
 export type MaQueueResponse = MaQueueItem[];
-

--- a/src/components/MaQueue/types.ts
+++ b/src/components/MaQueue/types.ts
@@ -1,18 +1,11 @@
 export interface MaQueueItem {
   queue_item_id: string;
-  name: string;
-  media_item: {
-    name: string;
-    image?: string | null;
-    album?: { image?: string | null };
-    artists?: { name: string }[];
-  };
+  media_title: string;
+  media_album_name?: string;
+  media_artist?: string;
+  media_content_id?: string;
+  media_image?: string;
 }
 
-export interface MaQueueResponse {
-  queue_id: string;
-  current_item: MaQueueItem | null;
-  next_item: MaQueueItem | null;
-  items?: MaQueueItem[];
-}
+export type MaQueueResponse = MaQueueItem[];
 

--- a/src/components/MaQueue/types.ts
+++ b/src/components/MaQueue/types.ts
@@ -1,0 +1,15 @@
+export interface MaQueueItem {
+  queue_item_id: string;
+  name: string;
+  media_item: {
+    name: string;
+    image?: string | null;
+    album?: { image?: string | null };
+    artists?: { name: string }[];
+  };
+}
+
+export interface MaQueueResponse {
+  items: MaQueueItem[];
+}
+

--- a/src/components/MaQueue/types.ts
+++ b/src/components/MaQueue/types.ts
@@ -10,6 +10,9 @@ export interface MaQueueItem {
 }
 
 export interface MaQueueResponse {
-  items: MaQueueItem[];
+  queue_id: string;
+  current_item: MaQueueItem | null;
+  next_item: MaQueueItem | null;
+  items?: MaQueueItem[];
 }
 

--- a/src/components/MaQueue/useQueue.ts
+++ b/src/components/MaQueue/useQueue.ts
@@ -1,0 +1,42 @@
+import { useEffect, useMemo, useState } from "preact/hooks";
+import { getHass } from "@utils";
+import { MaQueueResponse } from "./types";
+
+export const useQueue = (entityId: string) => {
+  const [queue, setQueue] = useState<MaQueueResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!entityId) return;
+
+    const fetchQueue = async () => {
+      setLoading(true);
+      const message = {
+        type: "call_service",
+        domain: "music_assistant",
+        service: "get_queue",
+        target: { entity_id: entityId },
+        service_data: {},
+        return_response: true,
+      };
+
+      const hass = getHass();
+      try {
+        const res = await hass.connection.sendMessagePromise(message);
+        const response = res as { response: MaQueueResponse };
+        if (response.response) {
+          setQueue(response.response);
+        }
+      } catch (e) {
+        console.error("Error fetching queue:", e);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchQueue();
+  }, [entityId]);
+
+  return useMemo(() => ({ queue, loading }), [queue, loading]);
+};
+

--- a/src/components/MaQueue/useQueue.ts
+++ b/src/components/MaQueue/useQueue.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "preact/hooks";
+import { useCallback, useEffect, useMemo, useState } from "preact/hooks";
 import { getHass } from "@utils";
 import { MaQueueItem, MaQueueResponse } from "./types";
 
@@ -6,42 +6,96 @@ export const useQueue = (entityId: string) => {
   const [queue, setQueue] = useState<MaQueueResponse>([]);
   const [loading, setLoading] = useState(false);
 
-  useEffect(() => {
+  const fetchQueue = useCallback(async () => {
     if (!entityId) return;
+    setLoading(true);
 
-    const fetchQueue = async () => {
-      setLoading(true);
-
-      const hass = getHass();
-      try {
-        if (!hass.services?.mass_queue?.get_queue_items) {
-          throw new Error("Service mass_queue.get_queue_items not found");
-        }
-
-        const message = {
-          type: "call_service",
-          domain: "mass_queue",
-          service: "get_queue_items",
-          service_data: {
-            entity: entityId,
-          },
-          return_response: true,
-        };
-
-        const res = await hass.connection.sendMessagePromise(message);
-        const response = res as { response: Record<string, MaQueueItem[]> };
-        const items = response.response?.[entityId] ?? [];
-        setQueue(items);
-      } catch (e) {
-        console.error("Error fetching queue items:", e);
-      } finally {
-        setLoading(false);
+    const hass = getHass();
+    try {
+      if (!hass.services?.mass_queue?.get_queue_items) {
+        throw new Error("Service mass_queue.get_queue_items not found");
       }
-    };
 
-    fetchQueue();
+      const message = {
+        type: "call_service",
+        domain: "mass_queue",
+        service: "get_queue_items",
+        service_data: {
+          entity: entityId,
+        },
+        return_response: true,
+      };
+
+      const res = await hass.connection.sendMessagePromise(message);
+      const response = res as { response: Record<string, MaQueueItem[]> };
+      const items = response.response?.[entityId] ?? [];
+      setQueue(items);
+    } catch (e) {
+      console.error("Error fetching queue items:", e);
+    } finally {
+      setLoading(false);
+    }
   }, [entityId]);
 
-  return useMemo(() => ({ queue, loading }), [queue, loading]);
-};
+  useEffect(() => {
+    fetchQueue();
+  }, [fetchQueue]);
 
+  const callService = useCallback(
+    async (service: string, queueItemId: string) => {
+      const hass = getHass();
+      try {
+        await hass.callService("mass_queue", service, {
+          entity: entityId,
+          queue_item_id: queueItemId,
+        });
+        await fetchQueue();
+      } catch (e) {
+        console.error(`Error calling ${service}:`, e);
+      }
+    },
+    [entityId, fetchQueue]
+  );
+
+  const removeQueueItem = useCallback(
+    async (id: string) => callService("remove_queue_item", id),
+    [callService]
+  );
+  const playQueueItem = useCallback(
+    async (id: string) => callService("play_queue_item", id),
+    [callService]
+  );
+  const moveQueueItemUp = useCallback(
+    async (id: string) => callService("move_queue_item_up", id),
+    [callService]
+  );
+  const moveQueueItemDown = useCallback(
+    async (id: string) => callService("move_queue_item_down", id),
+    [callService]
+  );
+  const moveQueueItemNext = useCallback(
+    async (id: string) => callService("move_queue_item_next", id),
+    [callService]
+  );
+
+  return useMemo(
+    () => ({
+      queue,
+      loading,
+      removeQueueItem,
+      playQueueItem,
+      moveQueueItemUp,
+      moveQueueItemDown,
+      moveQueueItemNext,
+    }),
+    [
+      queue,
+      loading,
+      removeQueueItem,
+      playQueueItem,
+      moveQueueItemUp,
+      moveQueueItemDown,
+      moveQueueItemNext,
+    ]
+  );
+};

--- a/src/components/MediaSearch/components/MediaTrack.tsx
+++ b/src/components/MediaSearch/components/MediaTrack.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useState } from "preact/hooks";
+import { JSX } from "preact/compat";
 import { MediaImage } from "./MediaImage";
 import { css } from "@emotion/react";
 
@@ -47,13 +48,22 @@ const styles = {
     width: 50,
     height: 50,
   }),
+  rootNotClickable: css({
+    cursor: "default",
+  }),
+  actions: css({
+    display: "flex",
+    gap: 4,
+    alignItems: "center",
+  }),
 };
 
 export type MediaTrackProps = {
   imageUrl?: string | null;
   title: string;
   artist?: string;
-  onClick: () => Promise<void>;
+  onClick?: () => Promise<void>;
+  actions?: JSX.Element;
 };
 
 export const MediaTrack = ({
@@ -61,10 +71,12 @@ export const MediaTrack = ({
   title,
   artist,
   onClick,
+  actions,
 }: MediaTrackProps) => {
   const [loading, setLoading] = useState(false);
   const [done, setDone] = useState(false);
   const handleOnClick = useCallback(async () => {
+    if (!onClick) return;
     setDone(false);
     setLoading(true);
     try {
@@ -77,7 +89,10 @@ export const MediaTrack = ({
   }, [onClick]);
 
   return (
-    <div css={styles.root} onClick={handleOnClick}>
+    <div
+      css={[styles.root, !onClick && styles.rootNotClickable]}
+      onClick={onClick ? handleOnClick : undefined}
+    >
       <MediaImage
         css={styles.mediaImage}
         imageUrl={imageUrl}
@@ -88,6 +103,7 @@ export const MediaTrack = ({
         <div css={styles.trackName}>{title}</div>
         {!!artist && <div css={styles.trackArtist}>{artist}</div>}
       </div>
+      {actions && <div css={styles.actions}>{actions}</div>}
     </div>
   );
 };

--- a/src/components/MediocreMassiveMediaPlayerCard/MediocreMassiveMediaPlayerCardEditor.tsx
+++ b/src/components/MediocreMassiveMediaPlayerCard/MediocreMassiveMediaPlayerCardEditor.tsx
@@ -317,44 +317,44 @@ export const MediocreMassiveMediaPlayerCardEditor: FC<
             )}
           </form.Field>
         </FormGroup>
-      <form.Field name="search.media_types">
-        {field => (
-          <HaSearchMediaTypesEditor
-            entityId={config.search?.entity_id ?? config.entity_id ?? ""}
-            hass={hass}
-            mediaTypes={field.state.value ?? []}
-            onChange={value => {
-              field.handleChange(value ?? []);
-            }}
-          />
-        )}
-      </form.Field>
-    </SubForm>
-
-    <SubForm title="Queue (optional)" error={getSubformError("queue")}>
-      <FormGroup>
-        <form.Field name="queue.enabled">
+        <form.Field name="search.media_types">
           {field => (
-            <ToggleContainer>
-              <Toggle
-                type="checkbox"
-                id="queue.enabled"
-                checked={field.state.value ?? false}
-                onChange={e =>
-                  field.handleChange((e.target as HTMLInputElement).checked)
-                }
-              />
-              <ToggleLabel htmlFor="queue.enabled">Enable Queue</ToggleLabel>
-            </ToggleContainer>
+            <HaSearchMediaTypesEditor
+              entityId={config.search?.entity_id ?? config.entity_id ?? ""}
+              hass={hass}
+              mediaTypes={field.state.value ?? []}
+              onChange={value => {
+                field.handleChange(value ?? []);
+              }}
+            />
           )}
         </form.Field>
-      </FormGroup>
-    </SubForm>
+      </SubForm>
 
-    <SubForm
-      title="Music Assistant Configuration (optional)"
-      error={
-        getSubformError("ma_entity_id") ??
+      <SubForm title="Queue (optional)" error={getSubformError("queue")}>
+        <FormGroup>
+          <form.Field name="queue.enabled">
+            {field => (
+              <ToggleContainer>
+                <Toggle
+                  type="checkbox"
+                  id="queue.enabled"
+                  checked={field.state.value ?? false}
+                  onChange={e =>
+                    field.handleChange((e.target as HTMLInputElement).checked)
+                  }
+                />
+                <ToggleLabel htmlFor="queue.enabled">Enable Queue</ToggleLabel>
+              </ToggleContainer>
+            )}
+          </form.Field>
+        </FormGroup>
+      </SubForm>
+
+      <SubForm
+        title="Music Assistant Configuration (optional)"
+        error={
+          getSubformError("ma_entity_id") ??
           getSubformError("ma_favorite_button_entity_id")
         }
       >

--- a/src/components/MediocreMassiveMediaPlayerCard/MediocreMassiveMediaPlayerCardEditor.tsx
+++ b/src/components/MediocreMassiveMediaPlayerCard/MediocreMassiveMediaPlayerCardEditor.tsx
@@ -317,24 +317,44 @@ export const MediocreMassiveMediaPlayerCardEditor: FC<
             )}
           </form.Field>
         </FormGroup>
-        <form.Field name="search.media_types">
+      <form.Field name="search.media_types">
+        {field => (
+          <HaSearchMediaTypesEditor
+            entityId={config.search?.entity_id ?? config.entity_id ?? ""}
+            hass={hass}
+            mediaTypes={field.state.value ?? []}
+            onChange={value => {
+              field.handleChange(value ?? []);
+            }}
+          />
+        )}
+      </form.Field>
+    </SubForm>
+
+    <SubForm title="Queue (optional)" error={getSubformError("queue")}>
+      <FormGroup>
+        <form.Field name="queue.enabled">
           {field => (
-            <HaSearchMediaTypesEditor
-              entityId={config.search?.entity_id ?? config.entity_id ?? ""}
-              hass={hass}
-              mediaTypes={field.state.value ?? []}
-              onChange={value => {
-                field.handleChange(value ?? []);
-              }}
-            />
+            <ToggleContainer>
+              <Toggle
+                type="checkbox"
+                id="queue.enabled"
+                checked={field.state.value ?? false}
+                onChange={e =>
+                  field.handleChange((e.target as HTMLInputElement).checked)
+                }
+              />
+              <ToggleLabel htmlFor="queue.enabled">Enable Queue</ToggleLabel>
+            </ToggleContainer>
           )}
         </form.Field>
-      </SubForm>
+      </FormGroup>
+    </SubForm>
 
-      <SubForm
-        title="Music Assistant Configuration (optional)"
-        error={
-          getSubformError("ma_entity_id") ??
+    <SubForm
+      title="Music Assistant Configuration (optional)"
+      error={
+        getSubformError("ma_entity_id") ??
           getSubformError("ma_favorite_button_entity_id")
         }
       >

--- a/src/components/MediocreMassiveMediaPlayerCard/components/PlayerActions.tsx
+++ b/src/components/MediocreMassiveMediaPlayerCard/components/PlayerActions.tsx
@@ -1,6 +1,12 @@
 import { useCallback, useContext, useState } from "preact/hooks";
 import { css, keyframes } from "@emotion/react";
-import { HaSearch, IconButton, MaQueue, MaSearch, usePlayer } from "@components";
+import {
+  HaSearch,
+  IconButton,
+  MaQueue,
+  MaSearch,
+  usePlayer,
+} from "@components";
 import { CardContext, CardContextType } from "@components/CardContext";
 import { Fragment, ReactNode } from "preact/compat";
 import { VolumeController, VolumeTrigger } from "./VolumeController";
@@ -99,11 +105,7 @@ export const PlayerActions = () => {
   const hasQueue = hasMaSearch && queue?.enabled;
 
   const [selected, setSelected] = useState<
-    | "volume"
-    | "speaker-grouping"
-    | "custom-buttons"
-    | "search"
-    | "queue"
+    "volume" | "speaker-grouping" | "custom-buttons" | "search" | "queue"
   >();
 
   const toggleSelected = useCallback(

--- a/src/components/MediocreMassiveMediaPlayerCard/components/PlayerActions.tsx
+++ b/src/components/MediocreMassiveMediaPlayerCard/components/PlayerActions.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useContext, useState } from "preact/hooks";
 import { css, keyframes } from "@emotion/react";
-import { HaSearch, IconButton, MaSearch, usePlayer } from "@components";
+import { HaSearch, IconButton, MaQueue, MaSearch, usePlayer } from "@components";
 import { CardContext, CardContextType } from "@components/CardContext";
 import { Fragment, ReactNode } from "preact/compat";
 import { VolumeController, VolumeTrigger } from "./VolumeController";
@@ -84,6 +84,7 @@ export const PlayerActions = () => {
     speaker_group,
     ma_entity_id,
     search,
+    queue,
     ma_favorite_button_entity_id,
     options: { always_show_power_button: alwaysShowPowerButton } = {},
   } = config;
@@ -95,9 +96,14 @@ export const PlayerActions = () => {
 
   const hasMaSearch = ma_entity_id && ma_entity_id.length > 0;
   const hasSearch = hasMaSearch || search?.enabled;
+  const hasQueue = hasMaSearch && queue?.enabled;
 
   const [selected, setSelected] = useState<
-    "volume" | "speaker-grouping" | "custom-buttons" | "search"
+    | "volume"
+    | "speaker-grouping"
+    | "custom-buttons"
+    | "search"
+    | "queue"
   >();
 
   const toggleSelected = useCallback(
@@ -160,6 +166,16 @@ export const PlayerActions = () => {
           />
         )}
       </Modal>
+      <Modal
+        title="Queue"
+        isOpen={selected === "queue"}
+        onClose={() => setSelected(undefined)}
+        padding="16px 0px 16px 0px"
+      >
+        {ma_entity_id && (
+          <MaQueue entityId={ma_entity_id} horizontalPadding={16} />
+        )}
+      </Modal>
       {!!speaker_group && (
         <IconButton
           size="small"
@@ -201,6 +217,13 @@ export const PlayerActions = () => {
           size="small"
           icon={"mdi:magnify"}
           onClick={() => setSelected("search")}
+        />
+      )}
+      {hasQueue && (
+        <IconButton
+          size="small"
+          icon={"mdi:playlist-music"}
+          onClick={() => setSelected("queue")}
         />
       )}
       {(!isOn || alwaysShowPowerButton) && (

--- a/src/components/MediocreMediaPlayerCard/MediocreMediaPlayerCard.tsx
+++ b/src/components/MediocreMediaPlayerCard/MediocreMediaPlayerCard.tsx
@@ -8,6 +8,7 @@ import {
   PlaybackControls,
   PlayerInfo,
   Search,
+  Queue,
   SpeakerGrouping,
 } from "./components";
 import { AlbumArt, IconButton, usePlayer } from "@components";
@@ -81,6 +82,7 @@ export const MediocreMediaPlayerCard = () => {
     use_art_colors,
     ma_entity_id,
     search,
+    queue,
     options: {
       always_show_power_button: alwaysShowPowerButton,
       always_show_custom_buttons: alwaysShowCustomButtons,
@@ -90,6 +92,7 @@ export const MediocreMediaPlayerCard = () => {
   const hasCustomButtons = custom_buttons && custom_buttons.length > 0;
   const hasMaSearch = ma_entity_id && ma_entity_id.length > 0;
   const hasSearch = hasMaSearch || search?.enabled;
+  const hasQueue = hasMaSearch && queue?.enabled;
 
   const [showGrouping, setShowGrouping] = useState(false);
   const [showCustomButtons, setShowCustomButtons] = useState(
@@ -97,6 +100,7 @@ export const MediocreMediaPlayerCard = () => {
   );
   const [showVolumeSlider, setShowVolumeSlider] = useState(false);
   const [showSearch, setShowSearch] = useState(false);
+  const [showQueue, setShowQueue] = useState(false);
 
   const { artVars, haVars } = useArtworkColors();
 
@@ -206,6 +210,13 @@ export const MediocreMediaPlayerCard = () => {
                     icon={"mdi:magnify"}
                   />
                 )}
+                {hasQueue && (
+                  <IconButton
+                    size="x-small"
+                    onClick={() => setShowQueue(!showQueue)}
+                    icon={"mdi:playlist-music"}
+                  />
+                )}
               </div>
             </div>
             <div
@@ -251,6 +262,7 @@ export const MediocreMediaPlayerCard = () => {
         {showGrouping && hasGroupingFeature && <SpeakerGrouping />}
         {showCustomButtons && <CustomButtons />}
         {showSearch && <Search />}
+        {showQueue && <Queue />}
         {isPopupVisible && (
           <MassivePopUp
             visible={isPopupVisible}

--- a/src/components/MediocreMediaPlayerCard/MediocreMediaPlayerCardEditor.tsx
+++ b/src/components/MediocreMediaPlayerCard/MediocreMediaPlayerCardEditor.tsx
@@ -334,6 +334,28 @@ export const MediocreMediaPlayerCardEditor: FC<
         </form.Field>
       </SubForm>
 
+      <SubForm title="Queue (optional)" error={getSubformError("queue")}>
+        <FormGroup>
+          <form.Field name="queue.enabled">
+            {field => (
+              <ToggleContainer>
+                <Toggle
+                  type="checkbox"
+                  id="queue.enabled"
+                  checked={field.state.value ?? false}
+                  onChange={e =>
+                    field.handleChange((e.target as HTMLInputElement).checked)
+                  }
+                />
+                <ToggleLabel htmlFor="queue.enabled">
+                  Enable Queue
+                </ToggleLabel>
+              </ToggleContainer>
+            )}
+          </form.Field>
+        </FormGroup>
+      </SubForm>
+
       <SubForm
         title="Music Assistant Configuration (optional)"
         error={

--- a/src/components/MediocreMediaPlayerCard/MediocreMediaPlayerCardEditor.tsx
+++ b/src/components/MediocreMediaPlayerCard/MediocreMediaPlayerCardEditor.tsx
@@ -347,9 +347,7 @@ export const MediocreMediaPlayerCardEditor: FC<
                     field.handleChange((e.target as HTMLInputElement).checked)
                   }
                 />
-                <ToggleLabel htmlFor="queue.enabled">
-                  Enable Queue
-                </ToggleLabel>
+                <ToggleLabel htmlFor="queue.enabled">Enable Queue</ToggleLabel>
               </ToggleContainer>
             )}
           </form.Field>

--- a/src/components/MediocreMediaPlayerCard/components/Queue.tsx
+++ b/src/components/MediocreMediaPlayerCard/components/Queue.tsx
@@ -1,0 +1,31 @@
+import { useContext } from "preact/hooks";
+import type { MediocreMediaPlayerCardConfig } from "@types";
+import { CardContext, CardContextType } from "@components/CardContext";
+import { MaQueue } from "@components";
+import { css } from "@emotion/react";
+import { theme } from "@constants";
+
+const styles = {
+  root: css({
+    maxHeight: 300,
+    paddingTop: 12,
+    paddingBottom: 12,
+    borderTop: `0.5px solid ${theme.colors.onCardDivider}`,
+    overflowY: "auto",
+  }),
+};
+
+export const Queue = () => {
+  const { config } =
+    useContext<CardContextType<MediocreMediaPlayerCardConfig>>(CardContext);
+  const { ma_entity_id } = config;
+
+  if (!ma_entity_id) return null;
+
+  return (
+    <div css={styles.root}>
+      <MaQueue entityId={ma_entity_id} horizontalPadding={12} />
+    </div>
+  );
+};
+

--- a/src/components/MediocreMediaPlayerCard/components/Queue.tsx
+++ b/src/components/MediocreMediaPlayerCard/components/Queue.tsx
@@ -28,4 +28,3 @@ export const Queue = () => {
     </div>
   );
 };
-

--- a/src/components/MediocreMediaPlayerCard/components/index.ts
+++ b/src/components/MediocreMediaPlayerCard/components/index.ts
@@ -4,5 +4,6 @@ export * from "./MetaInfo";
 export * from "./PlaybackControls";
 export * from "./PlayerInfo";
 export * from "./Search";
+export * from "./Queue";
 export * from "./SpeakerGrouping";
 export * from "./VolumeSlider";

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -12,6 +12,7 @@ export * from "./Icon";
 export * from "./IconButton";
 export * from "./Input";
 export * from "./MaSearch";
+export * from "./MaQueue";
 export * from "./MediaSearch";
 export * from "./MediocreChipMediaPlayerGroupCard";
 export * from "./MediocreMassiveMediaPlayerCard";

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -34,6 +34,9 @@ const commonMediocreMediaPlayerCardConfigSchema = type({
     "entity_id?": type("string").or("null"), // entity_id of the media player to search on (optional will fall back to the entity_id of the card)
     "media_types?": searchMediaTypeSchema.array(),
   },
+  "queue?": {
+    "enabled?": "boolean | null", // Enables queue display
+  },
   "options?": commonMediocreMediaPlayerCardConfigOptionsSchema,
   "grid_options?": "unknown", // Home Assistant grid layout options (passed through without validation)
   "visibility?": "unknown", // Home Assistant visibility options (passed through without validation)

--- a/src/utils/cardConfigUtils.test.ts
+++ b/src/utils/cardConfigUtils.test.ts
@@ -78,6 +78,9 @@ describe("cardConfigUtils", () => {
         entity_id: null,
         media_types: [],
       });
+      expect(result.queue).toEqual({
+        enabled: false,
+      });
       expect(result.ma_entity_id).toBeNull();
       expect(result.custom_buttons).toEqual([]);
       expect(result.options).toEqual({
@@ -104,6 +107,7 @@ describe("cardConfigUtils", () => {
           entity_id: "media_player.search",
           media_types: [],
         },
+        queue: { enabled: true },
         ma_entity_id: "media_player.ma",
         ma_favorite_button_entity_id: "media_player.ma_favorite",
         custom_buttons: [
@@ -196,6 +200,7 @@ describe("cardConfigUtils", () => {
         entity_id: null,
         media_types: [],
       });
+      expect(result.queue).toEqual({ enabled: false });
       expect(result.ma_entity_id).toBeNull();
       expect(result.custom_buttons).toEqual([]);
       expect(result.options).toEqual({
@@ -215,6 +220,7 @@ describe("cardConfigUtils", () => {
         action: {},
         speaker_group: { entity_id: null, entities: [] },
         search: { enabled: false, show_favorites: false, entity_id: null },
+        queue: { enabled: false },
         ma_entity_id: null,
         custom_buttons: [],
         options: {
@@ -239,6 +245,7 @@ describe("cardConfigUtils", () => {
         action: {},
         speaker_group: { entity_id: null, entities: [] },
         search: { enabled: false, show_favorites: false, entity_id: null },
+        queue: { enabled: false },
         ma_entity_id: null,
         custom_buttons: [],
         options: {
@@ -269,6 +276,7 @@ describe("cardConfigUtils", () => {
         action: {},
         speaker_group: { entity_id: null, entities: [] },
         search: { enabled: false, show_favorites: false, entity_id: null },
+        queue: { enabled: false },
         ma_entity_id: null,
         custom_buttons: [],
         options: {
@@ -291,6 +299,7 @@ describe("cardConfigUtils", () => {
         action: {},
         speaker_group: { entity_id: null, entities: [] },
         search: { enabled: false, show_favorites: false, entity_id: null },
+        queue: { enabled: false },
         ma_entity_id: null,
         custom_buttons: [],
         options: {
@@ -321,6 +330,7 @@ describe("cardConfigUtils", () => {
         action: {},
         speaker_group: { entity_id: null, entities: [] },
         search: { enabled: false, show_favorites: false, entity_id: null },
+        queue: { enabled: false },
         ma_entity_id: null,
         custom_buttons: [],
         options: { always_show_power_button: false },
@@ -344,6 +354,7 @@ describe("cardConfigUtils", () => {
         action: {},
         speaker_group: { entity_id: null, entities: [] },
         search: { enabled: false, show_favorites: false, entity_id: null },
+        queue: { enabled: false },
         ma_entity_id: null,
         custom_buttons: [],
         options: { always_show_power_button: false },
@@ -373,6 +384,7 @@ describe("cardConfigUtils", () => {
         action: {},
         speaker_group: { entity_id: null, entities: [] },
         search: { enabled: false, show_favorites: false, entity_id: null },
+        queue: { enabled: false },
         ma_entity_id: null,
         custom_buttons: [],
         options: { always_show_power_button: false },

--- a/src/utils/cardConfigUtils.ts
+++ b/src/utils/cardConfigUtils.ts
@@ -24,6 +24,9 @@ export const getDefaultValuesFromConfig = (
     entity_id: config?.search?.entity_id ?? null,
     media_types: config?.search?.media_types ?? [],
   },
+  queue: {
+    enabled: config?.queue?.enabled ?? false,
+  },
   ma_entity_id: config?.ma_entity_id ?? null,
   ma_favorite_button_entity_id: config?.ma_favorite_button_entity_id ?? null,
   custom_buttons: config?.custom_buttons ?? [],
@@ -57,6 +60,9 @@ export const getDefaultValuesFromMassiveConfig = (
     show_favorites: config?.search?.show_favorites ?? false,
     entity_id: config?.search?.entity_id ?? null,
     media_types: config?.search?.media_types ?? [],
+  },
+  queue: {
+    enabled: config?.queue?.enabled ?? false,
   },
   ma_entity_id: config?.ma_entity_id ?? null,
   ma_favorite_button_entity_id: config?.ma_favorite_button_entity_id ?? null,
@@ -120,6 +126,10 @@ export const getSimpleConfigFromFormValues = (
     !config.search?.media_types
   ) {
     delete config.search;
+  }
+
+  if (!config.queue?.enabled) {
+    delete config.queue;
   }
 
   if (config.options?.always_show_power_button === false) {
@@ -189,6 +199,10 @@ export const getSimpleConfigFromMassiveFormValues = (
     !config.search?.media_types
   ) {
     delete config.search;
+  }
+
+  if (!config.queue?.enabled) {
+    delete config.queue;
   }
 
   if (config.options?.always_show_power_button === false) {


### PR DESCRIPTION
1. mention mass_queue Home Assistant custom component requirement in README
2. document mass_queue prerequisite in queue functionality guide
3. allow enabling queue display via new queue.enabled option
4. show Music Assistant queue in media player cards
5. document queue configuration
6. guard against missing mass_queue service
7. render queue items using new response shape