### PR TITLE
feat: fallback on `entity_picture_local`

### DIFF
--- a/src/components/AlbumArt/AlbumArt.tsx
+++ b/src/components/AlbumArt/AlbumArt.tsx
@@ -70,11 +70,13 @@ export const AlbumArt = ({
   const {
     media_title: title,
     media_artist: artist,
-    entity_picture: albumArt,
+    entity_picture,
+    entity_picture_local,
     icon,
     device_class: deviceClass,
     source,
   } = player.attributes;
+  const albumArt = entity_picture_local || entity_picture;
   const state = player.state;
 
   const [error, setError] = useState(false);

--- a/src/hooks/useArtworkColors.tsx
+++ b/src/hooks/useArtworkColors.tsx
@@ -10,8 +10,9 @@ const isDarkMode = () =>
 
 export function useArtworkColors() {
   const {
-    attributes: { entity_picture: albumArt },
+    attributes: { entity_picture, entity_picture_local },
   } = usePlayer();
+  const albumArt = entity_picture_local || entity_picture;
   // State for average color
   const [palette, setPalette] = useState<Palette | null>(null);
   // Track dark mode state

--- a/src/types/mediaPlayerEntity.ts
+++ b/src/types/mediaPlayerEntity.ts
@@ -42,6 +42,7 @@ export interface MediaPlayerEntityAttributes {
   icon?: string;
   friendly_name?: string;
   entity_picture?: string;
+  entity_picture_local?: string;
   volume_level?: number; // 0.0 to 1.0
   is_volume_muted?: boolean;
   shuffle?: boolean;

--- a/src/utils/getDidMediaPlayerUpdate.ts
+++ b/src/utils/getDidMediaPlayerUpdate.ts
@@ -22,6 +22,7 @@ export const getDidMediaPlayerUpdate = (
         "attributes.icon",
         "attributes.friendly_name",
         "attributes.entity_picture",
+        "attributes.entity_picture_local",
         "attributes.volume_level",
         "attributes.is_volume_muted",
         "attributes.source",


### PR DESCRIPTION
fix for #150

Tested by building and manually inserting code into `/www/community/mediocre-hass-media-player-cards/mediocre-hass-media-player-card.js`

Examples of it working with Sonos as a media source (top is with album art colors, bottom is without)

<img width="426" height="335" alt="Screenshot 2025-09-02 at 5 30 29 PM" src="https://github.com/user-attachments/assets/3ea458b5-aff8-4b94-b8d8-c6a0fa165670" />
<img width="410" height="340" alt="Screenshot 2025-09-02 at 5 32 53 PM" src="https://github.com/user-attachments/assets/6d2d0437-aa0a-448f-a832-105613f50d95" />
