### PR TITLE
fix: custom buttons

### DIFF
--- a/src/components/MediocreMassiveMediaPlayerCard/MediocreMassiveMediaPlayerCardEditor.tsx
+++ b/src/components/MediocreMassiveMediaPlayerCard/MediocreMassiveMediaPlayerCardEditor.tsx
@@ -101,14 +101,17 @@ export const MediocreMassiveMediaPlayerCardEditor: FC<
   }, [form]);
 
   const removeCustomButton = useCallback(
-    (index: number) => {
-      const currentButtons = form.getFieldValue("custom_buttons") || [];
-      const newButtons = [...currentButtons];
-      newButtons.splice(index, 1);
-      form.setFieldValue("custom_buttons", newButtons);
-    },
-    [form]
-  );
+      (index: number) => {
+        const newButtons = [...(form.getFieldValue("custom_buttons") || [])];
+        newButtons.splice(index, 1);
+
+        const newConfig = {
+          ...config,
+          custom_buttons: newButtons
+        };
+        updateConfig(newConfig);
+        form.setFieldValue("custom_buttons", newButtons);
+      }, [config, form, updateConfig]);
 
   // Reset form when config changes externally
   useEffect(() => {

--- a/src/components/MediocreMassiveMediaPlayerCard/MediocreMassiveMediaPlayerCardEditor.tsx
+++ b/src/components/MediocreMassiveMediaPlayerCard/MediocreMassiveMediaPlayerCardEditor.tsx
@@ -101,24 +101,26 @@ export const MediocreMassiveMediaPlayerCardEditor: FC<
 
     const newConfig = {
       ...config,
-      custom_buttons: newButtons
+      custom_buttons: newButtons,
     };
     updateConfig(newConfig);
     form.setFieldValue("custom_buttons", newButtons);
   }, [config, form, updateConfig]);
 
   const removeCustomButton = useCallback(
-      (index: number) => {
-        const newButtons = [...(form.getFieldValue("custom_buttons") || [])];
-        newButtons.splice(index, 1);
+    (index: number) => {
+      const newButtons = [...(form.getFieldValue("custom_buttons") || [])];
+      newButtons.splice(index, 1);
 
-        const newConfig = {
-          ...config,
-          custom_buttons: newButtons
-        };
-        updateConfig(newConfig);
-        form.setFieldValue("custom_buttons", newButtons);
-      }, [config, form, updateConfig]);
+      const newConfig = {
+        ...config,
+        custom_buttons: newButtons,
+      };
+      updateConfig(newConfig);
+      form.setFieldValue("custom_buttons", newButtons);
+    },
+    [config, form, updateConfig]
+  );
 
   // Reset form when config changes externally
   useEffect(() => {

--- a/src/components/MediocreMassiveMediaPlayerCard/MediocreMassiveMediaPlayerCardEditor.tsx
+++ b/src/components/MediocreMassiveMediaPlayerCard/MediocreMassiveMediaPlayerCardEditor.tsx
@@ -90,15 +90,22 @@ export const MediocreMassiveMediaPlayerCardEditor: FC<
 
   const addCustomButton = useCallback(() => {
     const currentButtons = form.getFieldValue("custom_buttons") || [];
-    form.setFieldValue("custom_buttons", [
+    const newButtons = [
       ...currentButtons,
       {
         icon: "mdi:paper-roll",
         name: "New Button",
         tap_action: { action: "toggle" },
       },
-    ]);
-  }, [form]);
+    ];
+
+    const newConfig = {
+      ...config,
+      custom_buttons: newButtons
+    };
+    updateConfig(newConfig);
+    form.setFieldValue("custom_buttons", newButtons);
+  }, [config, form, updateConfig]);
 
   const removeCustomButton = useCallback(
       (index: number) => {

--- a/src/components/MediocreMassiveMediaPlayerCard/MediocreMassiveMediaPlayerCardEditor.tsx
+++ b/src/components/MediocreMassiveMediaPlayerCard/MediocreMassiveMediaPlayerCardEditor.tsx
@@ -95,7 +95,7 @@ export const MediocreMassiveMediaPlayerCardEditor: FC<
       {
         icon: "mdi:paper-roll",
         name: "New Button",
-        tap_action: { action: "toggle" },
+        tap_action: { action: "toggle" as const },
       },
     ];
 

--- a/src/components/MediocreMediaPlayerCard/MediocreMediaPlayerCardEditor.tsx
+++ b/src/components/MediocreMediaPlayerCard/MediocreMediaPlayerCardEditor.tsx
@@ -91,7 +91,7 @@ export const MediocreMediaPlayerCardEditor: FC<
       {
         icon: "mdi:paper-roll",
         name: "New Button",
-        tap_action: { action: "toggle" },
+        tap_action: { action: "toggle" as const },
       },
     ];
 

--- a/src/components/MediocreMediaPlayerCard/MediocreMediaPlayerCardEditor.tsx
+++ b/src/components/MediocreMediaPlayerCard/MediocreMediaPlayerCardEditor.tsx
@@ -86,15 +86,22 @@ export const MediocreMediaPlayerCardEditor: FC<
 
   const addCustomButton = useCallback(() => {
     const currentButtons = form.getFieldValue("custom_buttons") || [];
-    form.setFieldValue("custom_buttons", [
+    const newButtons = [
       ...currentButtons,
       {
         icon: "mdi:paper-roll",
         name: "New Button",
         tap_action: { action: "toggle" },
       },
-    ]);
-  }, [form]);
+    ];
+
+    const newConfig = {
+      ...config,
+      custom_buttons: newButtons
+    };
+    updateConfig(newConfig);
+    form.setFieldValue("custom_buttons", newButtons);
+  }, [config, form, updateConfig]);
 
   const removeCustomButton = useCallback(
       (index: number) => {

--- a/src/components/MediocreMediaPlayerCard/MediocreMediaPlayerCardEditor.tsx
+++ b/src/components/MediocreMediaPlayerCard/MediocreMediaPlayerCardEditor.tsx
@@ -97,24 +97,26 @@ export const MediocreMediaPlayerCardEditor: FC<
 
     const newConfig = {
       ...config,
-      custom_buttons: newButtons
+      custom_buttons: newButtons,
     };
     updateConfig(newConfig);
     form.setFieldValue("custom_buttons", newButtons);
   }, [config, form, updateConfig]);
 
   const removeCustomButton = useCallback(
-      (index: number) => {
-        const newButtons = [...(form.getFieldValue("custom_buttons") || [])];
-        newButtons.splice(index, 1);
+    (index: number) => {
+      const newButtons = [...(form.getFieldValue("custom_buttons") || [])];
+      newButtons.splice(index, 1);
 
-        const newConfig = {
-          ...config,
-          custom_buttons: newButtons
-        };
-        updateConfig(newConfig);
-        form.setFieldValue("custom_buttons", newButtons);
-      }, [config, form, updateConfig]);
+      const newConfig = {
+        ...config,
+        custom_buttons: newButtons,
+      };
+      updateConfig(newConfig);
+      form.setFieldValue("custom_buttons", newButtons);
+    },
+    [config, form, updateConfig]
+  );
 
   // Reset form when config changes externally
   useEffect(() => {

--- a/src/components/MediocreMediaPlayerCard/MediocreMediaPlayerCardEditor.tsx
+++ b/src/components/MediocreMediaPlayerCard/MediocreMediaPlayerCardEditor.tsx
@@ -97,14 +97,17 @@ export const MediocreMediaPlayerCardEditor: FC<
   }, [form]);
 
   const removeCustomButton = useCallback(
-    (index: number) => {
-      const currentButtons = form.getFieldValue("custom_buttons") || [];
-      const newButtons = [...currentButtons];
-      newButtons.splice(index, 1);
-      form.setFieldValue("custom_buttons", newButtons);
-    },
-    [form]
-  );
+      (index: number) => {
+        const newButtons = [...(form.getFieldValue("custom_buttons") || [])];
+        newButtons.splice(index, 1);
+
+        const newConfig = {
+          ...config,
+          custom_buttons: newButtons
+        };
+        updateConfig(newConfig);
+        form.setFieldValue("custom_buttons", newButtons);
+      }, [config, form, updateConfig]);
 
   // Reset form when config changes externally
   useEffect(() => {


### PR DESCRIPTION
New:

https://github.com/user-attachments/assets/3bf1dfec-d5a3-419d-929e-d077902e5d76

Old:

https://github.com/user-attachments/assets/b80d8ff4-6bec-4d2d-b8ff-c294095bf0c3

Previously, when you clicked the “Remove Button” button, the preview was not updated and the whole thing worked a little incorrectly, but now everything works flawlessly.