### PR TITLE
fix: handle ungroupped players in player selection multi card

### DIFF
--- a/src/utils/selectActiveMultiMediaPlayer.ts
+++ b/src/utils/selectActiveMultiMediaPlayer.ts
@@ -28,7 +28,8 @@ export function selectActiveMultiMediaPlayer(
   ) {
     const groupState =
       hass.states[player?.speaker_group_entity_id || player.entity_id];
-    if (groupState.attributes.group_members?.[0] === groupState.entity_id) {
+    const members = groupState?.attributes?.group_members;
+    if (!members?.length || members[0] === groupState.entity_id) {
       return player;
     }
   }
@@ -42,7 +43,8 @@ export function selectActiveMultiMediaPlayer(
       )
     ) {
       const groupState = hass.states[p.speaker_group_entity_id || p.entity_id];
-      if (groupState.attributes.group_members?.[0] === groupState.entity_id) {
+      const members = groupState?.attributes?.group_members;
+      if (!members?.length || members[0] === groupState.entity_id) {
         player = p;
       }
     }


### PR DESCRIPTION
Fixes player selection for media players that aren't part of a speaker group.
The code assumed players always had a group_member attribute, so when a standalone player was playing it was not being selected.