### PR TITLE
feat: add footer icon customization for large player views pr1

### DIFF
--- a/src/components/MediocreLargeMultiMediaPlayerCard/components/FooterActions.tsx
+++ b/src/components/MediocreLargeMultiMediaPlayerCard/components/FooterActions.tsx
@@ -35,6 +35,12 @@ const styles = {
   }),
 };
 
+const defaultFooterIcons = {
+  player: "mdi:home",
+  search: "mdi:magnify",
+  media_browser: "mdi:folder-music",
+} as const;
+
 export type FooterActionsProps = {
   setNavigationRoute: (route: NavigationRoute) => void;
   navigationRoute: NavigationRoute;
@@ -61,6 +67,9 @@ export const FooterActions = memo<FooterActionsProps>(
     const hasSearch = getHasSearch(search, ma_entity_id);
     const hasMediaBrowser = getHasMediaBrowser(media_browser);
     const hasQueue = useCanDisplayQueue({ ma_entity_id, lms_entity_id });
+    const footerIcons = config.options?.ui?.footer_icons;
+    const getFooterIcon = (key: keyof typeof defaultFooterIcons) =>
+      footerIcons?.[key]?.trim() || defaultFooterIcons[key];
 
     if (config.size && config.size !== "large") return null;
 
@@ -71,7 +80,7 @@ export const FooterActions = memo<FooterActionsProps>(
         {!desktopMode && (
           <IconButton
             size="small"
-            icon={"mdi:home"}
+            icon={getFooterIcon("player")}
             onClick={() => setNavigationRoute("massive")}
             selected={navigationRoute === "massive"}
           />
@@ -79,7 +88,7 @@ export const FooterActions = memo<FooterActionsProps>(
         {hasSearch && (
           <IconButton
             size="small"
-            icon={"mdi:magnify"}
+            icon={getFooterIcon("search")}
             onClick={() => setNavigationRoute("search")}
             selected={navigationRoute === "search"}
           />
@@ -87,7 +96,7 @@ export const FooterActions = memo<FooterActionsProps>(
         {hasMediaBrowser && (
           <IconButton
             size="small"
-            icon={"mdi:folder-music"}
+            icon={getFooterIcon("media_browser")}
             onClick={() => setNavigationRoute("media-browser")}
             selected={navigationRoute === "media-browser"}
           />

--- a/src/components/MediocreMassiveMediaPlayerCard/MediocreMassiveMediaPlayerCardEditor.tsx
+++ b/src/components/MediocreMassiveMediaPlayerCard/MediocreMassiveMediaPlayerCardEditor.tsx
@@ -5,7 +5,7 @@ import {
 import { MediocreMassiveMediaPlayerCardConfig } from "@types";
 import { useCallback, useEffect } from "preact/hooks";
 import { useStore, ValidationErrorMap } from "@tanstack/react-form";
-import { FormGroup, SubForm, FormSelect } from "@components";
+import { FormGroup, SubForm, FormSelect, Label } from "@components";
 import { css } from "@emotion/react";
 import { FC } from "preact/compat";
 import {
@@ -219,6 +219,32 @@ export const MediocreMassiveMediaPlayerCardEditor: FC<
           formErrors={formErrorMap as ValidationErrorMap<unknown>}
           fields={{ custom_buttons: "custom_buttons" as never }} // todo this casting is stupid
         />
+      </SubForm>
+      <SubForm
+        title="UI Customization (optional)"
+        error={getSubformError("options.ui")}
+      >
+        <SubForm title="Footer / Navigation" error={getSubformError("options.ui.footer_icons")}>
+          <Label>Optional icon overrides for the large footer tabs.</Label>
+          <form.AppField
+            name="options.ui.footer_icons.player"
+            children={field => (
+              <field.Text label="Player / Home tab icon" isIconInput />
+            )}
+          />
+          <form.AppField
+            name="options.ui.footer_icons.search"
+            children={field => (
+              <field.Text label="Search tab icon" isIconInput />
+            )}
+          />
+          <form.AppField
+            name="options.ui.footer_icons.media_browser"
+            children={field => (
+              <field.Text label="Browse Media tab icon" isIconInput />
+            )}
+          />
+        </SubForm>
       </SubForm>
       <SubForm
         title="Additional options (optional)"

--- a/src/components/MediocreMultiMediaPlayerCard/MediocreMultiMediaPlayerCardEditor.tsx
+++ b/src/components/MediocreMultiMediaPlayerCard/MediocreMultiMediaPlayerCardEditor.tsx
@@ -553,7 +553,7 @@ export const MediocreMultiMediaPlayerCardEditor: FC<
           </form.Field>
         </FormGroup>
       </SubForm>
-      {(size === "large" || tapOpensPopup) && (
+      { size === "large" && (
         <SubForm
           title="UI Customization (optional)"
           error={getSubformError("options.ui")}

--- a/src/components/MediocreMultiMediaPlayerCard/MediocreMultiMediaPlayerCardEditor.tsx
+++ b/src/components/MediocreMultiMediaPlayerCard/MediocreMultiMediaPlayerCardEditor.tsx
@@ -117,6 +117,25 @@ export const MediocreMultiMediaPlayerCardEditor: FC<
         if (newConfig.search) {
           stripNulls(newConfig.search);
         }
+        if (newConfig.options?.ui?.footer_icons) {
+          Object.keys(newConfig.options.ui.footer_icons).forEach(key => {
+            const icon =
+              newConfig.options?.ui?.footer_icons?.[
+                key as keyof typeof newConfig.options.ui.footer_icons
+              ];
+            if (!icon?.trim()) {
+              delete newConfig.options?.ui?.footer_icons?.[
+                key as keyof typeof newConfig.options.ui.footer_icons
+              ];
+            }
+          });
+          if (Object.keys(newConfig.options.ui.footer_icons).length === 0) {
+            delete newConfig.options.ui.footer_icons;
+          }
+          if (Object.keys(newConfig.options.ui).length === 0) {
+            delete newConfig.options.ui;
+          }
+        }
 
         if (formApi.state.isValid) {
           if (JSON.stringify(config) !== JSON.stringify(newConfig)) {
@@ -131,6 +150,9 @@ export const MediocreMultiMediaPlayerCardEditor: FC<
   });
 
   const size = useStore(form.store, state => state.values.size);
+  const tapOpensPopup = useStore(form.store, state =>
+    "tap_opens_popup" in state.values ? state.values.tap_opens_popup : false
+  );
 
   const formErrorMap = useStore(form.store, state => state.errorMap);
   const getSubformError = useCallback(
@@ -531,6 +553,37 @@ export const MediocreMultiMediaPlayerCardEditor: FC<
           </form.Field>
         </FormGroup>
       </SubForm>
+      {(size === "large" || tapOpensPopup) && (
+        <SubForm
+          title="UI Customization (optional)"
+          error={getSubformError("options.ui")}
+        >
+          <SubForm
+            title="Footer / Navigation"
+            error={getSubformError("options.ui.footer_icons")}
+          >
+            <Label>Optional icon overrides for the large footer tabs.</Label>
+            <form.AppField
+              name="options.ui.footer_icons.player"
+              children={field => (
+                <field.Text label="Player / Home tab icon" isIconInput />
+              )}
+            />
+            <form.AppField
+              name="options.ui.footer_icons.search"
+              children={field => (
+                <field.Text label="Search tab icon" isIconInput />
+              )}
+            />
+            <form.AppField
+              name="options.ui.footer_icons.media_browser"
+              children={field => (
+                <field.Text label="Browse Media tab icon" isIconInput />
+              )}
+            />
+          </SubForm>
+        </SubForm>
+      )}
     </form.AppForm>
   );
 };

--- a/src/components/MediocreMultiMediaPlayerCard/MediocreMultiMediaPlayerCardEditor.tsx
+++ b/src/components/MediocreMultiMediaPlayerCard/MediocreMultiMediaPlayerCardEditor.tsx
@@ -150,9 +150,6 @@ export const MediocreMultiMediaPlayerCardEditor: FC<
   });
 
   const size = useStore(form.store, state => state.values.size);
-  const tapOpensPopup = useStore(form.store, state =>
-    "tap_opens_popup" in state.values ? state.values.tap_opens_popup : false
-  );
 
   const formErrorMap = useStore(form.store, state => state.errorMap);
   const getSubformError = useCallback(

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -119,7 +119,6 @@ export const MediocreMultiMediaPlayer = type({
 
 export const commonMediaPlayerCardOptions = type({
   "player_is_active_when?": "'playing' | 'playing_or_paused'", // When to consider a media player as active.
-  "ui?": uiCustomizationSchema, // UI customization overrides
   "show_volume_step_buttons?": "boolean", // Show volume step buttons + - on volume sliders
   "use_volume_up_down_for_step_buttons?": "boolean", // Use volume_up and volume_down services for step buttons instead of setting volume using set_volume. This breaks volume sync when step buttons are used.
   "use_experimental_lms_media_browser?": "boolean", // Use the experimental LMS media browser instead of the default one when an LMS entity is used and lyrion_cli integration is present.

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -13,7 +13,6 @@ const uiCustomizationSchema = type({
 
 const commonMediocreMediaPlayerCardConfigOptionsSchema = type({
   "always_show_power_button?": "boolean | null", // Always show the power button, even if the media player is on
-  "ui?": uiCustomizationSchema, // UI customization overrides
   "show_volume_step_buttons?": "boolean", // Show volume step buttons + - on volume sliders
   "use_volume_up_down_for_step_buttons?": "boolean", // Use volume_up and volume_down services for step buttons instead of setting volume using set_volume. This breaks volume sync when step buttons are used.
   "use_experimental_lms_media_browser?": "boolean", // Use the experimental LMS media browser instead of the default one when an LMS entity is used and lyrion_cli integration is present.

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -101,6 +101,9 @@ export const MediocreMediaPlayerCardConfigSchema =
 export const MediocreMassiveMediaPlayerCardConfigSchema =
   commonMediocreMediaPlayerCardConfigSchema.and({
     mode: "'panel'|'card'|'in-card'|'popup'", // don't document popup and multi as they are only for internal use
+    "options?": commonMediocreMediaPlayerCardConfigOptionsSchema.and({
+      "ui?": uiCustomizationSchema, // UI customization overrides
+    })
   });
 
 export const MediocreMultiMediaPlayer = type({

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -142,6 +142,7 @@ export const MediocreMultiMediaPlayerCardConfigSchema =
       "height?": "number | string", // height of the card (can be a number in px or a string with any css unit)
       "options?": commonMediaPlayerCardOptions.and({
         "hide_selected_player_header?": "boolean", // Hide the header of the selected player in the massive view
+        "ui?": uiCustomizationSchema, // UI customization overrides
         "transparent_background_on_home?": "boolean", // Makes the background transparent when the showing the massive player
         "default_tab?":
           "'massive'|'search'|'media-browser'|'speaker-grouping'|'custom-buttons'|'queue'", // The tab to show by default when the card loads

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -1,8 +1,19 @@
 import { type } from "arktype";
 import { interactionConfigSchema } from "./actionTypes";
 
+const footerIconsSchema = type({
+  "player?": "string",
+  "search?": "string",
+  "media_browser?": "string",
+});
+
+const uiCustomizationSchema = type({
+  "footer_icons?": footerIconsSchema, // Override footer/navigation tab icons
+});
+
 const commonMediocreMediaPlayerCardConfigOptionsSchema = type({
   "always_show_power_button?": "boolean | null", // Always show the power button, even if the media player is on
+  "ui?": uiCustomizationSchema, // UI customization overrides
   "show_volume_step_buttons?": "boolean", // Show volume step buttons + - on volume sliders
   "use_volume_up_down_for_step_buttons?": "boolean", // Use volume_up and volume_down services for step buttons instead of setting volume using set_volume. This breaks volume sync when step buttons are used.
   "use_experimental_lms_media_browser?": "boolean", // Use the experimental LMS media browser instead of the default one when an LMS entity is used and lyrion_cli integration is present.
@@ -108,6 +119,7 @@ export const MediocreMultiMediaPlayer = type({
 
 export const commonMediaPlayerCardOptions = type({
   "player_is_active_when?": "'playing' | 'playing_or_paused'", // When to consider a media player as active.
+  "ui?": uiCustomizationSchema, // UI customization overrides
   "show_volume_step_buttons?": "boolean", // Show volume step buttons + - on volume sliders
   "use_volume_up_down_for_step_buttons?": "boolean", // Use volume_up and volume_down services for step buttons instead of setting volume using set_volume. This breaks volume sync when step buttons are used.
   "use_experimental_lms_media_browser?": "boolean", // Use the experimental LMS media browser instead of the default one when an LMS entity is used and lyrion_cli integration is present.

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -16,6 +16,7 @@ const commonMediocreMediaPlayerCardConfigOptionsSchema = type({
   "show_volume_step_buttons?": "boolean", // Show volume step buttons + - on volume sliders
   "use_volume_up_down_for_step_buttons?": "boolean", // Use volume_up and volume_down services for step buttons instead of setting volume using set_volume. This breaks volume sync when step buttons are used.
   "use_experimental_lms_media_browser?": "boolean", // Use the experimental LMS media browser instead of the default one when an LMS entity is used and lyrion_cli integration is present.
+  "ui?": uiCustomizationSchema, // UI customization overrides
 });
 
 const searchMediaTypeSchema = type({
@@ -124,6 +125,7 @@ export const commonMediaPlayerCardOptions = type({
   "show_volume_step_buttons?": "boolean", // Show volume step buttons + - on volume sliders
   "use_volume_up_down_for_step_buttons?": "boolean", // Use volume_up and volume_down services for step buttons instead of setting volume using set_volume. This breaks volume sync when step buttons are used.
   "use_experimental_lms_media_browser?": "boolean", // Use the experimental LMS media browser instead of the default one when an LMS entity is used and lyrion_cli integration is present.
+  "ui?": uiCustomizationSchema, // UI customization overrides
 });
 
 export const commonMediaPlayerCardSchema = type({

--- a/src/utils/cardConfigUtils.test.ts
+++ b/src/utils/cardConfigUtils.test.ts
@@ -126,6 +126,12 @@ describe("cardConfigUtils", () => {
           always_show_custom_buttons: true,
           hide_when_group_child: true,
           hide_when_off: true,
+          ui: {
+            footer_icons: {
+              player: "mdi:play-circle",
+              media_browser: "mdi:bookshelf",
+            },
+          },
           show_volume_step_buttons: true,
           use_volume_up_down_for_step_buttons: true,
           use_experimental_lms_media_browser: false,
@@ -363,6 +369,41 @@ describe("cardConfigUtils", () => {
         media_browser: { enabled: true },
       });
     });
+
+    it("should preserve non-empty footer icon overrides and drop empty ones", () => {
+      const configWithFooterIcons: MediocreMediaPlayerCardConfig = {
+        type: "custom:mediocre-media-player-card",
+        entity_id: "media_player.test",
+        use_art_colors: false,
+        tap_opens_popup: false,
+        action: {},
+        speaker_group: { entity_id: null, entities: [] },
+        search: { enabled: false, show_favorites: false, entity_id: null },
+        ma_entity_id: null,
+        custom_buttons: [],
+        options: {
+          always_show_power_button: false,
+          always_show_custom_buttons: false,
+          ui: {
+            footer_icons: {
+              player: "mdi:play",
+              search: " ",
+            },
+          },
+        },
+        media_browser: { enabled: false },
+      };
+
+      const result = getSimpleConfigFromFormValues(configWithFooterIcons);
+
+      expect(result.options).toEqual({
+        ui: {
+          footer_icons: {
+            player: "mdi:play",
+          },
+        },
+      });
+    });
   });
 
   describe("getSimpleConfigFromMassiveFormValues", () => {
@@ -448,6 +489,42 @@ describe("cardConfigUtils", () => {
         mode: "card",
         grid_options: { columns: "full" },
         media_browser: { enabled: true },
+      });
+    });
+
+    it("should preserve non-empty footer icon overrides and drop empty ones", () => {
+      const configWithFooterIcons: MediocreMassiveMediaPlayerCardConfig = {
+        type: "custom:mediocre-massive-media-player-card",
+        entity_id: "media_player.test",
+        mode: "card",
+        use_art_colors: false,
+        action: {},
+        speaker_group: { entity_id: null, entities: [] },
+        search: { enabled: false, show_favorites: false, entity_id: null },
+        ma_entity_id: null,
+        custom_buttons: [],
+        options: {
+          always_show_power_button: false,
+          ui: {
+            footer_icons: {
+              media_browser: "mdi:playlist-music",
+              search: "",
+            },
+          },
+        },
+        media_browser: { enabled: false },
+      };
+
+      const result = getSimpleConfigFromMassiveFormValues(
+        configWithFooterIcons
+      );
+
+      expect(result.options).toEqual({
+        ui: {
+          footer_icons: {
+            media_browser: "mdi:playlist-music",
+          },
+        },
       });
     });
   });

--- a/src/utils/cardConfigUtils.ts
+++ b/src/utils/cardConfigUtils.ts
@@ -4,6 +4,16 @@ import {
 } from "@types";
 import { getSearchEntryArray } from "./getSearchEntryArray";
 
+const getCleanFooterIcons = (
+  footerIcons?: Record<string, string | undefined>
+) => {
+  const entries = Object.entries(footerIcons ?? {}).filter(
+    ([, icon]) => !!icon?.trim()
+  );
+
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+};
+
 /**
  * Creates default values from a regular media player card config
  */
@@ -41,6 +51,15 @@ export const getDefaultValuesFromConfig = (
       config?.options?.show_volume_step_buttons ?? false,
     use_volume_up_down_for_step_buttons:
       config?.options?.use_volume_up_down_for_step_buttons ?? false,
+    ...(config?.options?.ui?.footer_icons
+      ? {
+          ui: {
+            footer_icons: {
+              ...config.options.ui.footer_icons,
+            },
+          },
+        }
+      : {}),
     use_experimental_lms_media_browser:
       config?.options?.use_experimental_lms_media_browser ?? false,
   },
@@ -80,6 +99,15 @@ export const getDefaultValuesFromMassiveConfig = (
       config?.options?.show_volume_step_buttons ?? false,
     use_volume_up_down_for_step_buttons:
       config?.options?.use_volume_up_down_for_step_buttons ?? false,
+    ...(config?.options?.ui?.footer_icons
+      ? {
+          ui: {
+            footer_icons: {
+              ...config.options.ui.footer_icons,
+            },
+          },
+        }
+      : {}),
     use_experimental_lms_media_browser:
       config?.options?.use_experimental_lms_media_browser ?? false,
   },
@@ -144,6 +172,21 @@ export const getSimpleConfigFromFormValues = (
   }
   if (config.options?.use_volume_up_down_for_step_buttons === false) {
     delete config.options.use_volume_up_down_for_step_buttons;
+  }
+  const footerIcons = getCleanFooterIcons(config.options?.ui?.footer_icons);
+  if (footerIcons) {
+    config.options = {
+      ...config.options,
+      ui: {
+        ...config.options?.ui,
+        footer_icons: footerIcons,
+      },
+    };
+  } else if (config.options?.ui?.footer_icons) {
+    delete config.options.ui.footer_icons;
+  }
+  if (config.options?.ui && Object.keys(config.options.ui).length === 0) {
+    delete config.options.ui;
   }
   if (config.options?.use_experimental_lms_media_browser === false) {
     delete config.options.use_experimental_lms_media_browser;
@@ -210,6 +253,21 @@ export const getSimpleConfigFromMassiveFormValues = (
   }
   if (config.options?.use_volume_up_down_for_step_buttons === false) {
     delete config.options.use_volume_up_down_for_step_buttons;
+  }
+  const footerIcons = getCleanFooterIcons(config.options?.ui?.footer_icons);
+  if (footerIcons) {
+    config.options = {
+      ...config.options,
+      ui: {
+        ...config.options?.ui,
+        footer_icons: footerIcons,
+      },
+    };
+  } else if (config.options?.ui?.footer_icons) {
+    delete config.options.ui.footer_icons;
+  }
+  if (config.options?.ui && Object.keys(config.options.ui).length === 0) {
+    delete config.options.ui;
   }
   if (config.options?.use_experimental_lms_media_browser === false) {
     delete config.options.use_experimental_lms_media_browser;

--- a/src/utils/getMediocreLegacyConfigToMultiConfig.test.ts
+++ b/src/utils/getMediocreLegacyConfigToMultiConfig.test.ts
@@ -43,6 +43,12 @@ describe("getMediocreLegacyConfigToMediocreMultiConfig", () => {
       always_show_power_button: false,
       hide_when_group_child: false,
       hide_when_off: false,
+      ui: {
+        footer_icons: {
+          player: "mdi:play-circle",
+          media_browser: "mdi:bookshelf",
+        },
+      },
     },
   };
 
@@ -63,6 +69,12 @@ describe("getMediocreLegacyConfigToMediocreMultiConfig", () => {
           always_show_power_button: false,
           hide_when_group_child: false,
           hide_when_off: false,
+          ui: {
+            footer_icons: {
+              player: "mdi:play-circle",
+              media_browser: "mdi:bookshelf",
+            },
+          },
         }),
         media_players: [
           expect.objectContaining({

--- a/src/utils/getMediocreLegacyConfigToMultiConfig.ts
+++ b/src/utils/getMediocreLegacyConfigToMultiConfig.ts
@@ -57,6 +57,15 @@ export const getMediocreLegacyConfigToMediocreMultiConfig = (
         config.options?.show_volume_step_buttons ?? false,
       use_volume_up_down_for_step_buttons:
         config.options?.use_volume_up_down_for_step_buttons ?? false,
+      ...(config.options?.ui?.footer_icons
+        ? {
+            ui: {
+              footer_icons: {
+                ...config.options.ui.footer_icons,
+              },
+            },
+          }
+        : {}),
       always_show_custom_buttons:
         config.options?.always_show_custom_buttons ?? false,
       always_show_power_button:

--- a/src/utils/getMediocreMassiveLegacyConfigToMultiConfig.ts
+++ b/src/utils/getMediocreMassiveLegacyConfigToMultiConfig.ts
@@ -58,6 +58,15 @@ export const getMediocreMassiveLegacyConfigToMediocreMultiConfig = (
         config.options?.show_volume_step_buttons ?? false,
       use_volume_up_down_for_step_buttons:
         config.options?.use_volume_up_down_for_step_buttons ?? false,
+      ...(config.options?.ui?.footer_icons
+        ? {
+            ui: {
+              footer_icons: {
+                ...config.options.ui.footer_icons,
+              },
+            },
+          }
+        : {}),
       transparent_background_on_home:
         config.mode === "panel" ||
         config.mode === "in-card" ||

--- a/src/utils/getMultiConfigToMediocreMassiveConfig.test.ts
+++ b/src/utils/getMultiConfigToMediocreMassiveConfig.test.ts
@@ -51,6 +51,12 @@ describe("getMultiConfigToMediocreMassiveConfig", () => {
     options: {
       show_volume_step_buttons: true,
       use_volume_up_down_for_step_buttons: false,
+      ui: {
+        footer_icons: {
+          player: "mdi:play-circle",
+          media_browser: "mdi:playlist-music",
+        },
+      },
     },
     size: "large",
     mode: "panel",
@@ -103,6 +109,12 @@ describe("getMultiConfigToMediocreMassiveConfig", () => {
         options: {
           show_volume_step_buttons: true,
           use_volume_up_down_for_step_buttons: false,
+          ui: {
+            footer_icons: {
+              player: "mdi:play-circle",
+              media_browser: "mdi:playlist-music",
+            },
+          },
           use_experimental_lms_media_browser: false,
         },
       })

--- a/src/utils/getMultiConfigToMediocreMassiveConfig.ts
+++ b/src/utils/getMultiConfigToMediocreMassiveConfig.ts
@@ -42,6 +42,15 @@ export const getMultiConfigToMediocreMassiveConfig = (
         config.options?.show_volume_step_buttons ?? false,
       use_volume_up_down_for_step_buttons:
         config.options?.use_volume_up_down_for_step_buttons ?? false,
+      ...(config.options?.ui?.footer_icons
+        ? {
+            ui: {
+              footer_icons: {
+                ...config.options.ui.footer_icons,
+              },
+            },
+          }
+        : {}),
       use_experimental_lms_media_browser:
         config.options?.use_experimental_lms_media_browser ?? false,
     },


### PR DESCRIPTION
## Summary

This PR adds a small UI customization feature for the large player footer/navigation tabs.

Supported icon overrides:

- player
- search
- media browser

Config shape:

```yaml
options:
  ui:
    footer_icons:
      player: mdi:play-network
      media_browser: mdi:bookshelf
```

<img width="1030" height="1178" alt="image" src="https://github.com/user-attachments/assets/df2d966c-b26f-4876-9d2e-840eddeda889" />

---

<img width="964" height="140" alt="image" src="https://github.com/user-attachments/assets/3f1381a8-2e5c-4239-b81d-ed366f14ea0e" />

###Why
The goal is to allow a small amount of visual customization without adding a broad set of new options.

This keeps the feature narrow and config-first:

- only footer/navigation icons
- no custom titles
- no additional behavior flags

###Editor support

This is available in both:

- Mediocre Massive Media Player Card
- Mediocre Multi Media Player Card

In both editors it lives under:

- UI Customization (optional)
      - Footer / Navigation

###Validation
yarn tsc --noEmit
yarn test
yarn build
