### PR TITLE
feat: multi card config inheritance pr2

### DIFF
--- a/src/components/MediocreLargeMultiMediaPlayerCard/components/FooterActions.tsx
+++ b/src/components/MediocreLargeMultiMediaPlayerCard/components/FooterActions.tsx
@@ -61,6 +61,17 @@ export const FooterActions = memo<FooterActionsProps>(
     const hasSearch = getHasSearch(search, ma_entity_id);
     const hasMediaBrowser = getHasMediaBrowser(media_browser);
     const hasQueue = useCanDisplayQueue({ ma_entity_id, lms_entity_id });
+    const footerMoreActionsForced =
+      config.options?.always_show_footer_more_actions;
+    const playerViewIcon = config.options?.player_view_icon?.trim() || "mdi:home";
+    const mediaBrowserViewIcon =
+      config.options?.media_browser_view_icon?.trim() || "mdi:folder-music";
+    const showDirectCustomButton =
+      !!custom_buttons &&
+      custom_buttons.length === 1 &&
+      footerMoreActionsForced !== true;
+    const showFooterMoreActionsButton =
+      (custom_buttons?.length ?? 0) > 1 || footerMoreActionsForced === true;
 
     if (config.size && config.size !== "large") return null;
 
@@ -71,7 +82,7 @@ export const FooterActions = memo<FooterActionsProps>(
         {!desktopMode && (
           <IconButton
             size="small"
-            icon={"mdi:home"}
+            icon={playerViewIcon}
             onClick={() => setNavigationRoute("massive")}
             selected={navigationRoute === "massive"}
           />
@@ -87,7 +98,7 @@ export const FooterActions = memo<FooterActionsProps>(
         {hasMediaBrowser && (
           <IconButton
             size="small"
-            icon={"mdi:folder-music"}
+            icon={mediaBrowserViewIcon}
             onClick={() => setNavigationRoute("media-browser")}
             selected={navigationRoute === "media-browser"}
           />
@@ -100,13 +111,13 @@ export const FooterActions = memo<FooterActionsProps>(
             selected={navigationRoute === "queue"}
           />
         )}
-        {custom_buttons && custom_buttons.length === 1 && !ma_entity_id ? (
+        {showDirectCustomButton ? (
           <CustomButton
             button={custom_buttons[0]}
             rootElement={rootElement}
             entityId={entity_id}
           />
-        ) : (custom_buttons && custom_buttons.length > 1) || ma_entity_id ? (
+        ) : showFooterMoreActionsButton ? (
           <IconButton
             size="small"
             icon={"mdi:dots-horizontal"}

--- a/src/components/MediocreLargeMultiMediaPlayerCard/components/MediaBrowserView.tsx
+++ b/src/components/MediocreLargeMultiMediaPlayerCard/components/MediaBrowserView.tsx
@@ -30,11 +30,15 @@ export const MediaBrowserView = memo<MediaBrowserViewProps>(({ height }) => {
       CardContext
     );
 
+  const configuredTitle = config?.options?.media_browser_view_title?.trim();
   const renderHeader = () => (
     <ViewHeader
-      title={t({
-        id: "MediocreMultiMediaPlayerCard.MediaBrowserView.browse_media_title",
-      })}
+      title={
+        configuredTitle ||
+        t({
+          id: "MediocreMultiMediaPlayerCard.MediaBrowserView.browse_media_title",
+        })
+      }
       css={styles.header}
     />
   );

--- a/src/components/MediocreLargeMultiMediaPlayerCard/components/SearchView.tsx
+++ b/src/components/MediocreLargeMultiMediaPlayerCard/components/SearchView.tsx
@@ -4,13 +4,16 @@ import {
   useSearchProviderMenu,
   Chip,
   Icon,
+  CardContext,
+  CardContextType,
 } from "@components";
 import { css } from "@emotion/react";
 import { ViewHeader } from "./ViewHeader";
 import { useIntl } from "@components/i18n";
-import { memo } from "preact/compat";
+import { memo, useContext } from "preact/compat";
 import { OverlayMenu } from "@components/OverlayMenu/OverlayMenu";
 import { useSelectedPlayer } from "@components/SelectedPlayerContext";
+import { MediocreMultiMediaPlayerCardConfig } from "@types";
 
 const styles = {
   root: css({
@@ -29,6 +32,8 @@ export type SearchViewProps = {
 export const SearchView = memo<SearchViewProps>(({ height }) => {
   const { selectedPlayer } = useSelectedPlayer();
   const { ma_entity_id, search, entity_id } = selectedPlayer!;
+  const { config } =
+    useContext<CardContextType<MediocreMultiMediaPlayerCardConfig>>(CardContext);
   const { selectedSearchProvider, searchProvidersMenu } = useSearchProviderMenu(
     search,
     entity_id,
@@ -36,17 +41,19 @@ export const SearchView = memo<SearchViewProps>(({ height }) => {
   );
 
   const { t } = useIntl();
+  const configuredTitle = config?.options?.search_view_title?.trim();
 
   const renderHeader = () => (
     <ViewHeader
       title={
-        selectedSearchProvider?.entity_id === ma_entity_id
+        configuredTitle ||
+        (selectedSearchProvider?.entity_id === ma_entity_id
           ? t({
               id: "MediocreMultiMediaPlayerCard.SearchView.search_in_ma_title",
             })
           : t({
               id: "MediocreMultiMediaPlayerCard.SearchView.search_title",
-            })
+            }))
       }
       css={styles.header}
       renderAction={

--- a/src/components/SelectedPlayerContext/SelectedPlayerContext.tsx
+++ b/src/components/SelectedPlayerContext/SelectedPlayerContext.tsx
@@ -8,6 +8,7 @@ import {
 } from "preact/hooks";
 import { CardContext, CardContextType } from "@components/CardContext";
 import { useHass } from "@components/HassContext";
+import { getResolvedMultiMediaPlayer } from "@utils";
 import { selectActiveMultiMediaPlayer } from "@utils/selectActiveMultiMediaPlayer";
 import {
   MediocreMultiMediaPlayer,
@@ -70,12 +71,18 @@ export const SelectedPlayerProvider = ({
     lastInteractionRef.current = Date.now();
   }, []);
 
+  const resolvedSelectedPlayer = getResolvedMultiMediaPlayer(config, selectedPlayer);
+
   return (
     <SelectedPlayerContext.Provider
-      value={{ selectedPlayer, setSelectedPlayer, setLastInteraction }}
+      value={{
+        selectedPlayer: resolvedSelectedPlayer,
+        setSelectedPlayer,
+        setLastInteraction,
+      }}
     >
       <PlayerContextProvider
-        entityId={selectedPlayer?.entity_id || config.entity_id}
+        entityId={resolvedSelectedPlayer?.entity_id || config.entity_id}
       >
         {children}
       </PlayerContextProvider>

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -3,6 +3,11 @@ import { interactionConfigSchema } from "./actionTypes";
 
 const commonMediocreMediaPlayerCardConfigOptionsSchema = type({
   "always_show_power_button?": "boolean | null", // Always show the power button, even if the media player is on
+  "always_show_footer_more_actions?": "boolean", // Always show the footer more-actions button in the large view, even when no custom buttons are configured
+  "media_browser_view_icon?": "string", // Icon for the media browser tab in the large footer navigation
+  "media_browser_view_title?": "string", // Custom title shown for the large Browse Media view
+  "player_view_icon?": "string", // Icon for the main player tab in the large footer navigation
+  "search_view_title?": "string", // Custom title shown for the large search view
   "show_volume_step_buttons?": "boolean", // Show volume step buttons + - on volume sliders
   "use_volume_up_down_for_step_buttons?": "boolean", // Use volume_up and volume_down services for step buttons instead of setting volume using set_volume. This breaks volume sync when step buttons are used.
   "use_experimental_lms_media_browser?": "boolean", // Use the experimental LMS media browser instead of the default one when an LMS entity is used and lyrion_cli integration is present.
@@ -107,7 +112,12 @@ export const MediocreMultiMediaPlayer = type({
 });
 
 export const commonMediaPlayerCardOptions = type({
+  "always_show_footer_more_actions?": "boolean", // Always show the footer more-actions button in the large view, even when no custom buttons are configured
+  "media_browser_view_icon?": "string", // Icon for the media browser tab in the large footer navigation
+  "media_browser_view_title?": "string", // Custom title shown for the large Browse Media view
+  "player_view_icon?": "string", // Icon for the main player tab in the large footer navigation
   "player_is_active_when?": "'playing' | 'playing_or_paused'", // When to consider a media player as active.
+  "search_view_title?": "string", // Custom title shown for the large search view
   "show_volume_step_buttons?": "boolean", // Show volume step buttons + - on volume sliders
   "use_volume_up_down_for_step_buttons?": "boolean", // Use volume_up and volume_down services for step buttons instead of setting volume using set_volume. This breaks volume sync when step buttons are used.
   "use_experimental_lms_media_browser?": "boolean", // Use the experimental LMS media browser instead of the default one when an LMS entity is used and lyrion_cli integration is present.

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -29,10 +29,12 @@ export const mediaPlayerConfigEntityArray = mediaPlayerConfigEntity.array();
 const mediaBrowserEntry = type({
   "name?": "string | null",
   entity_id: type("string"),
+  "media_types?": searchMediaTypeSchema.array().or("undefined"),
 });
 const mediaBrowserLegacyEntry = type({
   "enabled?": "boolean | null", // Enables media browser functionality
   "entity_id?": type("string").or("null").or("undefined"), // entity_id of the media browser to use (optional will fall back to the entity_id of the card)
+  "media_types?": searchMediaTypeSchema.array().or("undefined"),
 });
 
 const mediaBrowser = type("null")
@@ -127,6 +129,7 @@ export const commonMediaPlayerCardSchema = type({
   type: "string",
   entity_id: "string", // entity id of the initially selected media player (used when player is active)
   media_players: MediocreMultiMediaPlayer.array(),
+  "media_browser?": mediaBrowser,
   "use_art_colors?": "boolean",
   "disable_player_focus_switching?": "boolean",
   "grid_options?": "unknown", // Home Assistant grid layout options (passed through without validation)

--- a/src/utils/cardConfigUtils.test.ts
+++ b/src/utils/cardConfigUtils.test.ts
@@ -89,8 +89,11 @@ describe("cardConfigUtils", () => {
       expect(result.options).toEqual({
         always_show_power_button: false,
         always_show_custom_buttons: false,
+        always_show_footer_more_actions: false,
         hide_when_off: false,
         hide_when_group_child: false,
+        media_browser_view_icon: "",
+        player_view_icon: "",
         show_volume_step_buttons: false,
         use_volume_up_down_for_step_buttons: false,
         use_experimental_lms_media_browser: false,
@@ -144,6 +147,12 @@ describe("cardConfigUtils", () => {
         ...fullConfig,
         name: null,
         media_browser: [{ entity_id: "media_player.browser" }],
+        options: {
+          ...fullConfig.options,
+          always_show_footer_more_actions: false,
+          media_browser_view_icon: "",
+          player_view_icon: "",
+        },
         search: [
           {
             name: "Search",
@@ -244,6 +253,9 @@ describe("cardConfigUtils", () => {
       expect(result.custom_buttons).toEqual([]);
       expect(result.options).toEqual({
         always_show_power_button: false,
+        always_show_footer_more_actions: false,
+        media_browser_view_icon: "",
+        player_view_icon: "",
         show_volume_step_buttons: false,
         use_volume_up_down_for_step_buttons: false,
         use_experimental_lms_media_browser: false,

--- a/src/utils/cardConfigUtils.ts
+++ b/src/utils/cardConfigUtils.ts
@@ -35,8 +35,18 @@ export const getDefaultValuesFromConfig = (
       config?.options?.always_show_power_button ?? false,
     always_show_custom_buttons:
       config?.options?.always_show_custom_buttons ?? false,
+    always_show_footer_more_actions:
+      config?.options?.always_show_footer_more_actions ?? false,
     hide_when_off: config?.options?.hide_when_off ?? false,
     hide_when_group_child: config?.options?.hide_when_group_child ?? false,
+    media_browser_view_icon: config?.options?.media_browser_view_icon ?? "",
+    ...(config?.options?.media_browser_view_title
+      ? { media_browser_view_title: config.options.media_browser_view_title }
+      : {}),
+    player_view_icon: config?.options?.player_view_icon ?? "",
+    ...(config?.options?.search_view_title
+      ? { search_view_title: config.options.search_view_title }
+      : {}),
     show_volume_step_buttons:
       config?.options?.show_volume_step_buttons ?? false,
     use_volume_up_down_for_step_buttons:
@@ -76,6 +86,16 @@ export const getDefaultValuesFromMassiveConfig = (
   options: {
     always_show_power_button:
       config?.options?.always_show_power_button ?? false,
+    always_show_footer_more_actions:
+      config?.options?.always_show_footer_more_actions ?? false,
+    media_browser_view_icon: config?.options?.media_browser_view_icon ?? "",
+    ...(config?.options?.media_browser_view_title
+      ? { media_browser_view_title: config.options.media_browser_view_title }
+      : {}),
+    player_view_icon: config?.options?.player_view_icon ?? "",
+    ...(config?.options?.search_view_title
+      ? { search_view_title: config.options.search_view_title }
+      : {}),
     show_volume_step_buttons:
       config?.options?.show_volume_step_buttons ?? false,
     use_volume_up_down_for_step_buttons:
@@ -142,6 +162,21 @@ export const getSimpleConfigFromFormValues = (
   if (config.options?.show_volume_step_buttons === false) {
     delete config.options.show_volume_step_buttons;
   }
+  if (config.options?.always_show_footer_more_actions === false) {
+    delete config.options.always_show_footer_more_actions;
+  }
+  if (!config.options?.media_browser_view_icon) {
+    delete config.options?.media_browser_view_icon;
+  }
+  if (!config.options?.media_browser_view_title) {
+    delete config.options?.media_browser_view_title;
+  }
+  if (!config.options?.player_view_icon) {
+    delete config.options?.player_view_icon;
+  }
+  if (!config.options?.search_view_title) {
+    delete config.options?.search_view_title;
+  }
   if (config.options?.use_volume_up_down_for_step_buttons === false) {
     delete config.options.use_volume_up_down_for_step_buttons;
   }
@@ -204,6 +239,21 @@ export const getSimpleConfigFromMassiveFormValues = (
 
   if (config.options?.always_show_power_button === false) {
     delete config.options.always_show_power_button;
+  }
+  if (config.options?.always_show_footer_more_actions === false) {
+    delete config.options.always_show_footer_more_actions;
+  }
+  if (!config.options?.media_browser_view_icon) {
+    delete config.options?.media_browser_view_icon;
+  }
+  if (!config.options?.media_browser_view_title) {
+    delete config.options?.media_browser_view_title;
+  }
+  if (!config.options?.player_view_icon) {
+    delete config.options?.player_view_icon;
+  }
+  if (!config.options?.search_view_title) {
+    delete config.options?.search_view_title;
   }
   if (config.options?.show_volume_step_buttons === false) {
     delete config.options.show_volume_step_buttons;

--- a/src/utils/getMediaBrowserEntryArray.test.ts
+++ b/src/utils/getMediaBrowserEntryArray.test.ts
@@ -1,0 +1,35 @@
+import { getHasMediaBrowserEntryArray } from "./getMediaBrowserEntryArray";
+
+describe("getHasMediaBrowserEntryArray", () => {
+  it("returns array configs unchanged", () => {
+    const config = [
+      {
+        entity_id: "media_player.browser",
+        name: "Browser",
+        media_types: [{ media_type: "artists" }],
+      },
+    ];
+
+    expect(
+      getHasMediaBrowserEntryArray(config, "media_player.fallback")
+    ).toEqual(config);
+  });
+
+  it("converts legacy config to an entry array and preserves media_types", () => {
+    expect(
+      getHasMediaBrowserEntryArray(
+        {
+          enabled: true,
+          entity_id: "media_player.browser",
+          media_types: [{ media_type: "playlists", name: "Playlists" }],
+        },
+        "media_player.fallback"
+      )
+    ).toEqual([
+      {
+        entity_id: "media_player.browser",
+        media_types: [{ media_type: "playlists", name: "Playlists" }],
+      },
+    ]);
+  });
+});

--- a/src/utils/getMediaBrowserEntryArray.ts
+++ b/src/utils/getMediaBrowserEntryArray.ts
@@ -8,5 +8,12 @@ export const getHasMediaBrowserEntryArray = (
     return mediaBrowser;
   }
 
-  return [{ entity_id: mediaBrowser?.entity_id ?? fallbackEntityId }];
+  return [
+    {
+      entity_id: mediaBrowser?.entity_id ?? fallbackEntityId,
+      ...(mediaBrowser?.media_types
+        ? { media_types: mediaBrowser.media_types }
+        : {}),
+    },
+  ];
 };

--- a/src/utils/getMediocreLegacyConfigToMultiConfig.test.ts
+++ b/src/utils/getMediocreLegacyConfigToMultiConfig.test.ts
@@ -123,6 +123,7 @@ describe("getMediocreLegacyConfigToMediocreMultiConfig", () => {
       show_volume_step_buttons: false,
       use_volume_up_down_for_step_buttons: false,
       use_experimental_lms_media_browser: false,
+      always_show_footer_more_actions: false,
       always_show_custom_buttons: false,
       always_show_power_button: false,
       hide_when_group_child: false,

--- a/src/utils/getMediocreLegacyConfigToMultiConfig.ts
+++ b/src/utils/getMediocreLegacyConfigToMultiConfig.ts
@@ -61,8 +61,22 @@ export const getMediocreLegacyConfigToMediocreMultiConfig = (
         config.options?.always_show_custom_buttons ?? false,
       always_show_power_button:
         config.options?.always_show_power_button ?? false,
+      always_show_footer_more_actions:
+        config.options?.always_show_footer_more_actions ?? false,
       hide_when_group_child: config.options?.hide_when_group_child ?? false,
       hide_when_off: config.options?.hide_when_off ?? false,
+      ...(config.options?.media_browser_view_icon
+        ? { media_browser_view_icon: config.options.media_browser_view_icon }
+        : {}),
+      ...(config.options?.media_browser_view_title
+        ? { media_browser_view_title: config.options.media_browser_view_title }
+        : {}),
+      ...(config.options?.player_view_icon
+        ? { player_view_icon: config.options.player_view_icon }
+        : {}),
+      ...(config.options?.search_view_title
+        ? { search_view_title: config.options.search_view_title }
+        : {}),
       use_experimental_lms_media_browser:
         config.options?.use_experimental_lms_media_browser ?? false,
     },

--- a/src/utils/getMediocreMassiveLegacyConfigToMultiConfig.ts
+++ b/src/utils/getMediocreMassiveLegacyConfigToMultiConfig.ts
@@ -62,6 +62,20 @@ export const getMediocreMassiveLegacyConfigToMediocreMultiConfig = (
         config.mode === "panel" ||
         config.mode === "in-card" ||
         config.mode === "popup",
+      always_show_footer_more_actions:
+        config.options?.always_show_footer_more_actions ?? false,
+      ...(config.options?.media_browser_view_icon
+        ? { media_browser_view_icon: config.options.media_browser_view_icon }
+        : {}),
+      ...(config.options?.media_browser_view_title
+        ? { media_browser_view_title: config.options.media_browser_view_title }
+        : {}),
+      ...(config.options?.player_view_icon
+        ? { player_view_icon: config.options.player_view_icon }
+        : {}),
+      ...(config.options?.search_view_title
+        ? { search_view_title: config.options.search_view_title }
+        : {}),
       use_experimental_lms_media_browser:
         config.options?.use_experimental_lms_media_browser ?? false,
     },

--- a/src/utils/getMultiConfigToMediocreMassiveConfig.test.ts
+++ b/src/utils/getMultiConfigToMediocreMassiveConfig.test.ts
@@ -101,6 +101,7 @@ describe("getMultiConfigToMediocreMassiveConfig", () => {
           ],
         },
         options: {
+          always_show_footer_more_actions: false,
           show_volume_step_buttons: true,
           use_volume_up_down_for_step_buttons: false,
           use_experimental_lms_media_browser: false,
@@ -171,6 +172,7 @@ describe("getMultiConfigToMediocreMassiveConfig", () => {
       "panel"
     );
     expect(result.options).toEqual({
+      always_show_footer_more_actions: false,
       show_volume_step_buttons: false,
       use_volume_up_down_for_step_buttons: false,
       use_experimental_lms_media_browser: false,

--- a/src/utils/getMultiConfigToMediocreMassiveConfig.ts
+++ b/src/utils/getMultiConfigToMediocreMassiveConfig.ts
@@ -38,6 +38,20 @@ export const getMultiConfigToMediocreMassiveConfig = (
     speaker_group:
       speaker_group.entities.length > 1 ? speaker_group : undefined,
     options: {
+      always_show_footer_more_actions:
+        config.options?.always_show_footer_more_actions ?? false,
+      ...(config.options?.media_browser_view_icon
+        ? { media_browser_view_icon: config.options.media_browser_view_icon }
+        : {}),
+      ...(config.options?.media_browser_view_title
+        ? { media_browser_view_title: config.options.media_browser_view_title }
+        : {}),
+      ...(config.options?.player_view_icon
+        ? { player_view_icon: config.options.player_view_icon }
+        : {}),
+      ...(config.options?.search_view_title
+        ? { search_view_title: config.options.search_view_title }
+        : {}),
       show_volume_step_buttons:
         config.options?.show_volume_step_buttons ?? false,
       use_volume_up_down_for_step_buttons:

--- a/src/utils/getResolvedMultiMediaPlayer.test.ts
+++ b/src/utils/getResolvedMultiMediaPlayer.test.ts
@@ -1,0 +1,51 @@
+import { MediocreMultiMediaPlayerCardConfig } from "@types";
+import { getResolvedMultiMediaPlayer } from "./getResolvedMultiMediaPlayer";
+
+describe("getResolvedMultiMediaPlayer", () => {
+  it("falls back to root media_browser when the player does not define one", () => {
+    const config = {
+      media_browser: [
+        {
+          entity_id: "media_player.shared_browser",
+          name: "Shared Browser",
+          media_types: [{ media_type: "artists" }, { media_type: "albums" }],
+        },
+      ],
+    } as Pick<MediocreMultiMediaPlayerCardConfig, "media_browser">;
+
+    const player = {
+      entity_id: "media_player.kitchen",
+      name: "Kitchen",
+    };
+
+    expect(getResolvedMultiMediaPlayer(config, player)).toEqual({
+      ...player,
+      media_browser: config.media_browser,
+    });
+  });
+
+  it("keeps the player's own media_browser when present", () => {
+    const config = {
+      media_browser: [
+        {
+          entity_id: "media_player.shared_browser",
+          name: "Shared Browser",
+        },
+      ],
+    } as Pick<MediocreMultiMediaPlayerCardConfig, "media_browser">;
+
+    const player = {
+      entity_id: "media_player.office",
+      name: "Office",
+      media_browser: [
+        {
+          entity_id: "media_player.office_browser",
+          name: "Office Browser",
+          media_types: [{ media_type: "tracks" }],
+        },
+      ],
+    };
+
+    expect(getResolvedMultiMediaPlayer(config, player)).toEqual(player);
+  });
+});

--- a/src/utils/getResolvedMultiMediaPlayer.ts
+++ b/src/utils/getResolvedMultiMediaPlayer.ts
@@ -1,0 +1,15 @@
+import { MediocreMultiMediaPlayer, MediocreMultiMediaPlayerCardConfig } from "@types";
+
+export const getResolvedMultiMediaPlayer = (
+  config: Pick<MediocreMultiMediaPlayerCardConfig, "media_browser">,
+  player?: MediocreMultiMediaPlayer
+): MediocreMultiMediaPlayer | undefined => {
+  if (!player) {
+    return undefined;
+  }
+
+  return {
+    ...player,
+    media_browser: player.media_browser ?? config.media_browser,
+  };
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -17,6 +17,7 @@ export * from "./getIsDarkMode";
 export * from "./getIsLmsPlayer";
 export * from "./getIsMassPlayer";
 export * from "./getMediaBrowserEntryArray";
+export * from "./getResolvedMultiMediaPlayer";
 export * from "./getMediaPlayerTitleAndSubtitle";
 export * from "./getMediocreLegacyConfigToMultiConfig";
 export * from "./getMultiConfigToMediocreMassiveConfig";


### PR DESCRIPTION
## Summary

This PR adds root-level `media_browser` support to the multi-player card and makes the selected player inherit that shared media browser config when it does not define its own.

This is intentionally a narrow follow-up to PR 1.

This is part of a batch of bite-sized PR's, that in aggregate create some cool new functionality.

## Why

On the current `v0.30.0` multi-player implementation, the large footer only shows the Browse Media tab when the **selected player** has a `media_browser` config.

In practice, that means this kind of config looks reasonable but does not behave the way a user would expect:

```yaml
type: custom:mediocre-multi-media-player-card
entity_id: media_player.ma_basement_sonos
media_browser:
  enabled: true
media_players:
  - entity_id: media_player.ma_basement_sonos
 ```
  
looks like it has a root-level media browser configured, but the selected player never sees it.

In practice, that makes the Browse Media tab disappear unless `media_browser` is duplicated onto the selected player entry.

This can be awkward for users and inconsistent with how a multi-card-level shared configuration is expected to behave.

In many setups (like MA in particular) one should be able to inherit the card level media_browser OR override it in the media_player.
And in a media_player.
media_browser: [] would override it with null!
