### PR TITLE
feat: add configurable trailing button for the large volume row pr3

### DIFF
--- a/src/components/MediocreLargeMultiMediaPlayerCard/components/FooterActions.tsx
+++ b/src/components/MediocreLargeMultiMediaPlayerCard/components/FooterActions.tsx
@@ -61,6 +61,17 @@ export const FooterActions = memo<FooterActionsProps>(
     const hasSearch = getHasSearch(search, ma_entity_id);
     const hasMediaBrowser = getHasMediaBrowser(media_browser);
     const hasQueue = useCanDisplayQueue({ ma_entity_id, lms_entity_id });
+    const footerMoreActionsForced =
+      config.options?.always_show_footer_more_actions;
+    const playerViewIcon = config.options?.player_view_icon?.trim() || "mdi:home";
+    const mediaBrowserViewIcon =
+      config.options?.media_browser_view_icon?.trim() || "mdi:folder-music";
+    const showDirectCustomButton =
+      !!custom_buttons &&
+      custom_buttons.length === 1 &&
+      footerMoreActionsForced !== true;
+    const showFooterMoreActionsButton =
+      (custom_buttons?.length ?? 0) > 1 || footerMoreActionsForced === true;
 
     if (config.size && config.size !== "large") return null;
 
@@ -71,7 +82,7 @@ export const FooterActions = memo<FooterActionsProps>(
         {!desktopMode && (
           <IconButton
             size="small"
-            icon={"mdi:home"}
+            icon={playerViewIcon}
             onClick={() => setNavigationRoute("massive")}
             selected={navigationRoute === "massive"}
           />
@@ -87,7 +98,7 @@ export const FooterActions = memo<FooterActionsProps>(
         {hasMediaBrowser && (
           <IconButton
             size="small"
-            icon={"mdi:folder-music"}
+            icon={mediaBrowserViewIcon}
             onClick={() => setNavigationRoute("media-browser")}
             selected={navigationRoute === "media-browser"}
           />
@@ -100,13 +111,13 @@ export const FooterActions = memo<FooterActionsProps>(
             selected={navigationRoute === "queue"}
           />
         )}
-        {custom_buttons && custom_buttons.length === 1 && !ma_entity_id ? (
+        {showDirectCustomButton ? (
           <CustomButton
             button={custom_buttons[0]}
             rootElement={rootElement}
             entityId={entity_id}
           />
-        ) : (custom_buttons && custom_buttons.length > 1) || ma_entity_id ? (
+        ) : showFooterMoreActionsButton ? (
           <IconButton
             size="small"
             icon={"mdi:dots-horizontal"}

--- a/src/components/MediocreLargeMultiMediaPlayerCard/components/MassiveView.tsx
+++ b/src/components/MediocreLargeMultiMediaPlayerCard/components/MassiveView.tsx
@@ -1,4 +1,7 @@
-import type { MediocreMultiMediaPlayerCardConfig } from "@types";
+import type {
+  CustomButton as CustomButtonConfig,
+  MediocreMultiMediaPlayerCardConfig,
+} from "@types";
 import { css } from "@emotion/react";
 import { useCallback, useContext, useMemo } from "preact/hooks";
 import { CardContext, CardContextType } from "@components/CardContext";
@@ -179,10 +182,70 @@ export const MassiveViewView = memo<MassiveViewViewProps>(
                 config.options?.use_volume_up_down_for_step_buttons ?? false
               }
             />
-            <IconButton size="small" onClick={togglePower} icon={"mdi:power"} />
+            <VolumeTrailingButton
+              buttonType={config.options?.volume_trailing_button ?? "power"}
+              customButton={mediaPlayer.volume_trailing_button_custom_button}
+              entityId={entity_id}
+              onPower={togglePower}
+              rootElement={rootElement}
+            />
           </div>
         </MassivePlaybackController>
       </div>
     );
   }
 );
+
+type VolumeTrailingButtonProps = {
+  buttonType: "power" | "custom" | "none";
+  customButton?: CustomButtonConfig | null;
+  entityId: string;
+  onPower: () => void;
+  rootElement: HTMLElement;
+};
+
+const VolumeTrailingButton = ({
+  buttonType,
+  customButton,
+  entityId,
+  onPower,
+  rootElement,
+}: VolumeTrailingButtonProps) => {
+  switch (buttonType) {
+    case "none":
+      return null;
+    case "custom":
+      if (!customButton) return null;
+      return (
+        <VolumeTrailingCustomButton
+          button={customButton}
+          entityId={entityId}
+          rootElement={rootElement}
+        />
+      );
+    case "power":
+    default:
+      return <IconButton size="small" onClick={onPower} icon={"mdi:power"} />;
+  }
+};
+
+const VolumeTrailingCustomButton = ({
+  button,
+  entityId,
+  rootElement,
+}: {
+  button: CustomButtonConfig;
+  entityId: string;
+  rootElement: HTMLElement;
+}) => {
+  const { icon: _icon, name: _name, ...actionConfig } = button;
+  const actionProps = useActionProps({
+    rootElement,
+    actionConfig: {
+      ...actionConfig,
+      entity: entityId,
+    },
+  });
+
+  return <IconButton icon={button.icon} size="small" {...actionProps} />;
+};

--- a/src/components/MediocreLargeMultiMediaPlayerCard/components/MediaBrowserView.tsx
+++ b/src/components/MediocreLargeMultiMediaPlayerCard/components/MediaBrowserView.tsx
@@ -30,11 +30,15 @@ export const MediaBrowserView = memo<MediaBrowserViewProps>(({ height }) => {
       CardContext
     );
 
+  const configuredTitle = config?.options?.media_browser_view_title?.trim();
   const renderHeader = () => (
     <ViewHeader
-      title={t({
-        id: "MediocreMultiMediaPlayerCard.MediaBrowserView.browse_media_title",
-      })}
+      title={
+        configuredTitle ||
+        t({
+          id: "MediocreMultiMediaPlayerCard.MediaBrowserView.browse_media_title",
+        })
+      }
       css={styles.header}
     />
   );

--- a/src/components/MediocreLargeMultiMediaPlayerCard/components/SearchView.tsx
+++ b/src/components/MediocreLargeMultiMediaPlayerCard/components/SearchView.tsx
@@ -4,13 +4,16 @@ import {
   useSearchProviderMenu,
   Chip,
   Icon,
+  CardContext,
+  CardContextType,
 } from "@components";
 import { css } from "@emotion/react";
 import { ViewHeader } from "./ViewHeader";
 import { useIntl } from "@components/i18n";
-import { memo } from "preact/compat";
+import { memo, useContext } from "preact/compat";
 import { OverlayMenu } from "@components/OverlayMenu/OverlayMenu";
 import { useSelectedPlayer } from "@components/SelectedPlayerContext";
+import { MediocreMultiMediaPlayerCardConfig } from "@types";
 
 const styles = {
   root: css({
@@ -29,6 +32,8 @@ export type SearchViewProps = {
 export const SearchView = memo<SearchViewProps>(({ height }) => {
   const { selectedPlayer } = useSelectedPlayer();
   const { ma_entity_id, search, entity_id } = selectedPlayer!;
+  const { config } =
+    useContext<CardContextType<MediocreMultiMediaPlayerCardConfig>>(CardContext);
   const { selectedSearchProvider, searchProvidersMenu } = useSearchProviderMenu(
     search,
     entity_id,
@@ -36,17 +41,19 @@ export const SearchView = memo<SearchViewProps>(({ height }) => {
   );
 
   const { t } = useIntl();
+  const configuredTitle = config?.options?.search_view_title?.trim();
 
   const renderHeader = () => (
     <ViewHeader
       title={
-        selectedSearchProvider?.entity_id === ma_entity_id
+        configuredTitle ||
+        (selectedSearchProvider?.entity_id === ma_entity_id
           ? t({
               id: "MediocreMultiMediaPlayerCard.SearchView.search_in_ma_title",
             })
           : t({
               id: "MediocreMultiMediaPlayerCard.SearchView.search_title",
-            })
+            }))
       }
       css={styles.header}
       renderAction={

--- a/src/components/SelectedPlayerContext/SelectedPlayerContext.tsx
+++ b/src/components/SelectedPlayerContext/SelectedPlayerContext.tsx
@@ -8,6 +8,7 @@ import {
 } from "preact/hooks";
 import { CardContext, CardContextType } from "@components/CardContext";
 import { useHass } from "@components/HassContext";
+import { getResolvedMultiMediaPlayer } from "@utils";
 import { selectActiveMultiMediaPlayer } from "@utils/selectActiveMultiMediaPlayer";
 import {
   MediocreMultiMediaPlayer,
@@ -70,12 +71,18 @@ export const SelectedPlayerProvider = ({
     lastInteractionRef.current = Date.now();
   }, []);
 
+  const resolvedSelectedPlayer = getResolvedMultiMediaPlayer(config, selectedPlayer);
+
   return (
     <SelectedPlayerContext.Provider
-      value={{ selectedPlayer, setSelectedPlayer, setLastInteraction }}
+      value={{
+        selectedPlayer: resolvedSelectedPlayer,
+        setSelectedPlayer,
+        setLastInteraction,
+      }}
     >
       <PlayerContextProvider
-        entityId={selectedPlayer?.entity_id || config.entity_id}
+        entityId={resolvedSelectedPlayer?.entity_id || config.entity_id}
       >
         {children}
       </PlayerContextProvider>

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -11,6 +11,7 @@ const commonMediocreMediaPlayerCardConfigOptionsSchema = type({
   "show_volume_step_buttons?": "boolean", // Show volume step buttons + - on volume sliders
   "use_volume_up_down_for_step_buttons?": "boolean", // Use volume_up and volume_down services for step buttons instead of setting volume using set_volume. This breaks volume sync when step buttons are used.
   "use_experimental_lms_media_browser?": "boolean", // Use the experimental LMS media browser instead of the default one when an LMS entity is used and lyrion_cli integration is present.
+  "volume_trailing_button?": "'power' | 'custom' | 'none'", // Button shown to the right of the large view volume slider
 });
 
 const searchMediaTypeSchema = type({
@@ -79,6 +80,8 @@ const commonMediocreMediaPlayerCardConfigSchema = type({
   "lms_entity_id?": type("string").or("null").or("undefined"), // LMS entity_id (adds LMS specific features)
   "search?": searchConfig,
   "media_browser?": mediaBrowser,
+  "volume_trailing_button_custom_button?":
+    customButton.or("null").or("undefined"),
   "options?": commonMediocreMediaPlayerCardConfigOptionsSchema,
   "grid_options?": "unknown", // Home Assistant grid layout options (passed through without validation)
   "visibility?": "unknown", // Home Assistant visibility options (passed through without validation)
@@ -110,6 +113,8 @@ export const MediocreMultiMediaPlayer = type({
   "lms_entity_id?": type("string").or("null").or("undefined"), // LMS entity_id (adds LMS specific features)
   "search?": searchConfig,
   "media_browser?": mediaBrowser,
+  "volume_trailing_button_custom_button?":
+    customButton.or("null").or("undefined"),
   "action?": interactionConfigSchema,
 });
 
@@ -123,6 +128,7 @@ export const commonMediaPlayerCardOptions = type({
   "show_volume_step_buttons?": "boolean", // Show volume step buttons + - on volume sliders
   "use_volume_up_down_for_step_buttons?": "boolean", // Use volume_up and volume_down services for step buttons instead of setting volume using set_volume. This breaks volume sync when step buttons are used.
   "use_experimental_lms_media_browser?": "boolean", // Use the experimental LMS media browser instead of the default one when an LMS entity is used and lyrion_cli integration is present.
+  "volume_trailing_button?": "'power' | 'custom' | 'none'", // Button shown to the right of the large view volume slider
 });
 
 export const commonMediaPlayerCardSchema = type({

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -3,6 +3,11 @@ import { interactionConfigSchema } from "./actionTypes";
 
 const commonMediocreMediaPlayerCardConfigOptionsSchema = type({
   "always_show_power_button?": "boolean | null", // Always show the power button, even if the media player is on
+  "always_show_footer_more_actions?": "boolean", // Always show the footer more-actions button in the large view, even when no custom buttons are configured
+  "media_browser_view_icon?": "string", // Icon for the media browser tab in the large footer navigation
+  "media_browser_view_title?": "string", // Custom title shown for the large Browse Media view
+  "player_view_icon?": "string", // Icon for the main player tab in the large footer navigation
+  "search_view_title?": "string", // Custom title shown for the large search view
   "show_volume_step_buttons?": "boolean", // Show volume step buttons + - on volume sliders
   "use_volume_up_down_for_step_buttons?": "boolean", // Use volume_up and volume_down services for step buttons instead of setting volume using set_volume. This breaks volume sync when step buttons are used.
   "use_experimental_lms_media_browser?": "boolean", // Use the experimental LMS media browser instead of the default one when an LMS entity is used and lyrion_cli integration is present.
@@ -107,7 +112,12 @@ export const MediocreMultiMediaPlayer = type({
 });
 
 export const commonMediaPlayerCardOptions = type({
+  "always_show_footer_more_actions?": "boolean", // Always show the footer more-actions button in the large view, even when no custom buttons are configured
+  "media_browser_view_icon?": "string", // Icon for the media browser tab in the large footer navigation
+  "media_browser_view_title?": "string", // Custom title shown for the large Browse Media view
+  "player_view_icon?": "string", // Icon for the main player tab in the large footer navigation
   "player_is_active_when?": "'playing' | 'playing_or_paused'", // When to consider a media player as active.
+  "search_view_title?": "string", // Custom title shown for the large search view
   "show_volume_step_buttons?": "boolean", // Show volume step buttons + - on volume sliders
   "use_volume_up_down_for_step_buttons?": "boolean", // Use volume_up and volume_down services for step buttons instead of setting volume using set_volume. This breaks volume sync when step buttons are used.
   "use_experimental_lms_media_browser?": "boolean", // Use the experimental LMS media browser instead of the default one when an LMS entity is used and lyrion_cli integration is present.

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -29,10 +29,12 @@ export const mediaPlayerConfigEntityArray = mediaPlayerConfigEntity.array();
 const mediaBrowserEntry = type({
   "name?": "string | null",
   entity_id: type("string"),
+  "media_types?": searchMediaTypeSchema.array().or("undefined"),
 });
 const mediaBrowserLegacyEntry = type({
   "enabled?": "boolean | null", // Enables media browser functionality
   "entity_id?": type("string").or("null").or("undefined"), // entity_id of the media browser to use (optional will fall back to the entity_id of the card)
+  "media_types?": searchMediaTypeSchema.array().or("undefined"),
 });
 
 const mediaBrowser = type("null")
@@ -127,6 +129,7 @@ export const commonMediaPlayerCardSchema = type({
   type: "string",
   entity_id: "string", // entity id of the initially selected media player (used when player is active)
   media_players: MediocreMultiMediaPlayer.array(),
+  "media_browser?": mediaBrowser,
   "use_art_colors?": "boolean",
   "disable_player_focus_switching?": "boolean",
   "grid_options?": "unknown", // Home Assistant grid layout options (passed through without validation)

--- a/src/utils/cardConfigUtils.test.ts
+++ b/src/utils/cardConfigUtils.test.ts
@@ -89,11 +89,15 @@ describe("cardConfigUtils", () => {
       expect(result.options).toEqual({
         always_show_power_button: false,
         always_show_custom_buttons: false,
+        always_show_footer_more_actions: false,
         hide_when_off: false,
         hide_when_group_child: false,
+        media_browser_view_icon: "",
+        player_view_icon: "",
         show_volume_step_buttons: false,
         use_volume_up_down_for_step_buttons: false,
         use_experimental_lms_media_browser: false,
+        volume_trailing_button: "power",
       });
       expect(result.grid_options).toBeUndefined();
       expect(result.media_browser).toBeNull();
@@ -152,6 +156,14 @@ describe("cardConfigUtils", () => {
           },
         ],
         lms_entity_id: null,
+        volume_trailing_button_custom_button: null,
+        options: {
+          ...fullConfig.options,
+          always_show_footer_more_actions: false,
+          media_browser_view_icon: "",
+          player_view_icon: "",
+          volume_trailing_button: "power",
+        },
         visibility: undefined,
       });
     });
@@ -244,9 +256,13 @@ describe("cardConfigUtils", () => {
       expect(result.custom_buttons).toEqual([]);
       expect(result.options).toEqual({
         always_show_power_button: false,
+        always_show_footer_more_actions: false,
+        media_browser_view_icon: "",
+        player_view_icon: "",
         show_volume_step_buttons: false,
         use_volume_up_down_for_step_buttons: false,
         use_experimental_lms_media_browser: false,
+        volume_trailing_button: "power",
       });
       expect(result.media_browser).toBeNull();
       expect(result.grid_options).toBeUndefined();

--- a/src/utils/cardConfigUtils.trailingButton.test.ts
+++ b/src/utils/cardConfigUtils.trailingButton.test.ts
@@ -1,0 +1,104 @@
+import {
+  getDefaultValuesFromMassiveConfig,
+  getSimpleConfigFromFormValues,
+  getSimpleConfigFromMassiveFormValues,
+} from "@utils/cardConfigUtils";
+import {
+  MediocreMassiveMediaPlayerCardConfig,
+  MediocreMediaPlayerCardConfig,
+} from "@types";
+
+describe("cardConfigUtils trailing button fields", () => {
+  it("preserves large-card trailing button defaults in massive config", () => {
+    const config: MediocreMassiveMediaPlayerCardConfig = {
+      type: "custom:mediocre-massive-media-player-card",
+      entity_id: "media_player.test",
+      mode: "card",
+      volume_trailing_button_custom_button: {
+        icon: "mdi:heart",
+        name: "Favorite",
+        tap_action: { action: "toggle" },
+      },
+      options: {
+        player_view_icon: "mdi:speaker",
+        volume_trailing_button: "custom",
+      },
+    };
+
+    expect(getDefaultValuesFromMassiveConfig(config)).toEqual(
+      expect.objectContaining({
+        volume_trailing_button_custom_button: {
+          icon: "mdi:heart",
+          name: "Favorite",
+          tap_action: { action: "toggle" },
+        },
+        options: expect.objectContaining({
+          player_view_icon: "mdi:speaker",
+          volume_trailing_button: "custom",
+        }),
+      })
+    );
+  });
+
+  it("keeps explicitly configured regular-card trailing button fields", () => {
+    const config: MediocreMediaPlayerCardConfig = {
+      type: "custom:mediocre-media-player-card",
+      entity_id: "media_player.test",
+      volume_trailing_button_custom_button: {
+        icon: "mdi:heart",
+        name: "Favorite",
+        tap_action: { action: "toggle" },
+      },
+      options: {
+        player_view_icon: "mdi:speaker",
+        volume_trailing_button: "custom",
+      },
+    };
+
+    expect(getSimpleConfigFromFormValues(config)).toEqual(
+      expect.objectContaining({
+        volume_trailing_button_custom_button: {
+          icon: "mdi:heart",
+          name: "Favorite",
+          tap_action: { action: "toggle" },
+        },
+        options: {
+          player_view_icon: "mdi:speaker",
+          volume_trailing_button: "custom",
+        },
+      })
+    );
+  });
+
+  it("keeps explicitly configured massive-card trailing button fields", () => {
+    const config: MediocreMassiveMediaPlayerCardConfig = {
+      type: "custom:mediocre-massive-media-player-card",
+      entity_id: "media_player.test",
+      mode: "card",
+      volume_trailing_button_custom_button: {
+        icon: "mdi:heart",
+        name: "Favorite",
+        tap_action: { action: "toggle" },
+      },
+      options: {
+        player_view_icon: "mdi:speaker",
+        volume_trailing_button: "none",
+      },
+    };
+
+    expect(getSimpleConfigFromMassiveFormValues(config)).toEqual(
+      expect.objectContaining({
+        mode: "card",
+        volume_trailing_button_custom_button: {
+          icon: "mdi:heart",
+          name: "Favorite",
+          tap_action: { action: "toggle" },
+        },
+        options: {
+          player_view_icon: "mdi:speaker",
+          volume_trailing_button: "none",
+        },
+      })
+    );
+  });
+});

--- a/src/utils/cardConfigUtils.ts
+++ b/src/utils/cardConfigUtils.ts
@@ -30,6 +30,8 @@ export const getDefaultValuesFromConfig = (
   ma_favorite_button_entity_id: config?.ma_favorite_button_entity_id ?? null,
   lms_entity_id: config?.lms_entity_id ?? null,
   custom_buttons: config?.custom_buttons ?? [],
+  volume_trailing_button_custom_button:
+    config?.volume_trailing_button_custom_button ?? null,
   options: {
     always_show_power_button:
       config?.options?.always_show_power_button ?? false,
@@ -53,6 +55,7 @@ export const getDefaultValuesFromConfig = (
       config?.options?.use_volume_up_down_for_step_buttons ?? false,
     use_experimental_lms_media_browser:
       config?.options?.use_experimental_lms_media_browser ?? false,
+    volume_trailing_button: config?.options?.volume_trailing_button ?? "power",
   },
   grid_options: config?.grid_options,
   visibility: config?.visibility,
@@ -83,6 +86,8 @@ export const getDefaultValuesFromMassiveConfig = (
   ma_favorite_button_entity_id: config?.ma_favorite_button_entity_id ?? null,
   lms_entity_id: config?.lms_entity_id ?? null,
   custom_buttons: config?.custom_buttons ?? [],
+  volume_trailing_button_custom_button:
+    config?.volume_trailing_button_custom_button ?? null,
   options: {
     always_show_power_button:
       config?.options?.always_show_power_button ?? false,
@@ -102,6 +107,7 @@ export const getDefaultValuesFromMassiveConfig = (
       config?.options?.use_volume_up_down_for_step_buttons ?? false,
     use_experimental_lms_media_browser:
       config?.options?.use_experimental_lms_media_browser ?? false,
+    volume_trailing_button: config?.options?.volume_trailing_button ?? "power",
   },
   grid_options: config?.grid_options,
   visibility: config?.visibility,
@@ -132,6 +138,9 @@ export const getSimpleConfigFromFormValues = (
   if (!config.lms_entity_id) delete config.lms_entity_id;
   if (!config.custom_buttons || config.custom_buttons.length === 0)
     delete config.custom_buttons;
+  if (!config.volume_trailing_button_custom_button) {
+    delete config.volume_trailing_button_custom_button;
+  }
 
   if (config.speaker_group?.entity_id === null) {
     delete config.speaker_group.entity_id;
@@ -183,6 +192,12 @@ export const getSimpleConfigFromFormValues = (
   if (config.options?.use_experimental_lms_media_browser === false) {
     delete config.options.use_experimental_lms_media_browser;
   }
+  if (
+    !config.options?.volume_trailing_button ||
+    config.options.volume_trailing_button === "power"
+  ) {
+    delete config.options?.volume_trailing_button;
+  }
 
   if (Object.keys(config.options ?? {}).length === 0) {
     delete config.options;
@@ -223,6 +238,9 @@ export const getSimpleConfigFromMassiveFormValues = (
   if (!config.lms_entity_id) delete config.lms_entity_id;
   if (!config.custom_buttons || config.custom_buttons.length === 0)
     delete config.custom_buttons;
+  if (!config.volume_trailing_button_custom_button) {
+    delete config.volume_trailing_button_custom_button;
+  }
 
   if (config.speaker_group?.entity_id === null) {
     delete config.speaker_group.entity_id;
@@ -263,6 +281,12 @@ export const getSimpleConfigFromMassiveFormValues = (
   }
   if (config.options?.use_experimental_lms_media_browser === false) {
     delete config.options.use_experimental_lms_media_browser;
+  }
+  if (
+    !config.options?.volume_trailing_button ||
+    config.options.volume_trailing_button === "power"
+  ) {
+    delete config.options?.volume_trailing_button;
   }
 
   if (Object.keys(config.options ?? {}).length === 0) {

--- a/src/utils/cardConfigUtils.ts
+++ b/src/utils/cardConfigUtils.ts
@@ -35,8 +35,18 @@ export const getDefaultValuesFromConfig = (
       config?.options?.always_show_power_button ?? false,
     always_show_custom_buttons:
       config?.options?.always_show_custom_buttons ?? false,
+    always_show_footer_more_actions:
+      config?.options?.always_show_footer_more_actions ?? false,
     hide_when_off: config?.options?.hide_when_off ?? false,
     hide_when_group_child: config?.options?.hide_when_group_child ?? false,
+    media_browser_view_icon: config?.options?.media_browser_view_icon ?? "",
+    ...(config?.options?.media_browser_view_title
+      ? { media_browser_view_title: config.options.media_browser_view_title }
+      : {}),
+    player_view_icon: config?.options?.player_view_icon ?? "",
+    ...(config?.options?.search_view_title
+      ? { search_view_title: config.options.search_view_title }
+      : {}),
     show_volume_step_buttons:
       config?.options?.show_volume_step_buttons ?? false,
     use_volume_up_down_for_step_buttons:
@@ -76,6 +86,16 @@ export const getDefaultValuesFromMassiveConfig = (
   options: {
     always_show_power_button:
       config?.options?.always_show_power_button ?? false,
+    always_show_footer_more_actions:
+      config?.options?.always_show_footer_more_actions ?? false,
+    media_browser_view_icon: config?.options?.media_browser_view_icon ?? "",
+    ...(config?.options?.media_browser_view_title
+      ? { media_browser_view_title: config.options.media_browser_view_title }
+      : {}),
+    player_view_icon: config?.options?.player_view_icon ?? "",
+    ...(config?.options?.search_view_title
+      ? { search_view_title: config.options.search_view_title }
+      : {}),
     show_volume_step_buttons:
       config?.options?.show_volume_step_buttons ?? false,
     use_volume_up_down_for_step_buttons:
@@ -142,6 +162,21 @@ export const getSimpleConfigFromFormValues = (
   if (config.options?.show_volume_step_buttons === false) {
     delete config.options.show_volume_step_buttons;
   }
+  if (config.options?.always_show_footer_more_actions === false) {
+    delete config.options.always_show_footer_more_actions;
+  }
+  if (!config.options?.media_browser_view_icon) {
+    delete config.options?.media_browser_view_icon;
+  }
+  if (!config.options?.media_browser_view_title) {
+    delete config.options?.media_browser_view_title;
+  }
+  if (!config.options?.player_view_icon) {
+    delete config.options?.player_view_icon;
+  }
+  if (!config.options?.search_view_title) {
+    delete config.options?.search_view_title;
+  }
   if (config.options?.use_volume_up_down_for_step_buttons === false) {
     delete config.options.use_volume_up_down_for_step_buttons;
   }
@@ -204,6 +239,21 @@ export const getSimpleConfigFromMassiveFormValues = (
 
   if (config.options?.always_show_power_button === false) {
     delete config.options.always_show_power_button;
+  }
+  if (config.options?.always_show_footer_more_actions === false) {
+    delete config.options.always_show_footer_more_actions;
+  }
+  if (!config.options?.media_browser_view_icon) {
+    delete config.options?.media_browser_view_icon;
+  }
+  if (!config.options?.media_browser_view_title) {
+    delete config.options?.media_browser_view_title;
+  }
+  if (!config.options?.player_view_icon) {
+    delete config.options?.player_view_icon;
+  }
+  if (!config.options?.search_view_title) {
+    delete config.options?.search_view_title;
   }
   if (config.options?.show_volume_step_buttons === false) {
     delete config.options.show_volume_step_buttons;

--- a/src/utils/getMediaBrowserEntryArray.test.ts
+++ b/src/utils/getMediaBrowserEntryArray.test.ts
@@ -1,0 +1,35 @@
+import { getHasMediaBrowserEntryArray } from "./getMediaBrowserEntryArray";
+
+describe("getHasMediaBrowserEntryArray", () => {
+  it("returns array configs unchanged", () => {
+    const config = [
+      {
+        entity_id: "media_player.browser",
+        name: "Browser",
+        media_types: [{ media_type: "artists" }],
+      },
+    ];
+
+    expect(
+      getHasMediaBrowserEntryArray(config, "media_player.fallback")
+    ).toEqual(config);
+  });
+
+  it("converts legacy config to an entry array and preserves media_types", () => {
+    expect(
+      getHasMediaBrowserEntryArray(
+        {
+          enabled: true,
+          entity_id: "media_player.browser",
+          media_types: [{ media_type: "playlists", name: "Playlists" }],
+        },
+        "media_player.fallback"
+      )
+    ).toEqual([
+      {
+        entity_id: "media_player.browser",
+        media_types: [{ media_type: "playlists", name: "Playlists" }],
+      },
+    ]);
+  });
+});

--- a/src/utils/getMediaBrowserEntryArray.ts
+++ b/src/utils/getMediaBrowserEntryArray.ts
@@ -8,5 +8,12 @@ export const getHasMediaBrowserEntryArray = (
     return mediaBrowser;
   }
 
-  return [{ entity_id: mediaBrowser?.entity_id ?? fallbackEntityId }];
+  return [
+    {
+      entity_id: mediaBrowser?.entity_id ?? fallbackEntityId,
+      ...(mediaBrowser?.media_types
+        ? { media_types: mediaBrowser.media_types }
+        : {}),
+    },
+  ];
 };

--- a/src/utils/getMediocreLegacyConfigToMultiConfig.test.ts
+++ b/src/utils/getMediocreLegacyConfigToMultiConfig.test.ts
@@ -123,6 +123,7 @@ describe("getMediocreLegacyConfigToMediocreMultiConfig", () => {
       show_volume_step_buttons: false,
       use_volume_up_down_for_step_buttons: false,
       use_experimental_lms_media_browser: false,
+      always_show_footer_more_actions: false,
       always_show_custom_buttons: false,
       always_show_power_button: false,
       hide_when_group_child: false,

--- a/src/utils/getMediocreLegacyConfigToMultiConfig.ts
+++ b/src/utils/getMediocreLegacyConfigToMultiConfig.ts
@@ -61,8 +61,22 @@ export const getMediocreLegacyConfigToMediocreMultiConfig = (
         config.options?.always_show_custom_buttons ?? false,
       always_show_power_button:
         config.options?.always_show_power_button ?? false,
+      always_show_footer_more_actions:
+        config.options?.always_show_footer_more_actions ?? false,
       hide_when_group_child: config.options?.hide_when_group_child ?? false,
       hide_when_off: config.options?.hide_when_off ?? false,
+      ...(config.options?.media_browser_view_icon
+        ? { media_browser_view_icon: config.options.media_browser_view_icon }
+        : {}),
+      ...(config.options?.media_browser_view_title
+        ? { media_browser_view_title: config.options.media_browser_view_title }
+        : {}),
+      ...(config.options?.player_view_icon
+        ? { player_view_icon: config.options.player_view_icon }
+        : {}),
+      ...(config.options?.search_view_title
+        ? { search_view_title: config.options.search_view_title }
+        : {}),
       use_experimental_lms_media_browser:
         config.options?.use_experimental_lms_media_browser ?? false,
     },

--- a/src/utils/getMediocreLegacyConfigToMultiConfig.ts
+++ b/src/utils/getMediocreLegacyConfigToMultiConfig.ts
@@ -17,6 +17,8 @@ export const getMediocreLegacyConfigToMediocreMultiConfig = (
       lms_entity_id: config.lms_entity_id,
       search: config.search,
       media_browser: config.media_browser,
+      volume_trailing_button_custom_button:
+        config.volume_trailing_button_custom_button,
       custom_buttons: config.custom_buttons,
       can_be_grouped: true,
     },
@@ -76,6 +78,9 @@ export const getMediocreLegacyConfigToMediocreMultiConfig = (
         : {}),
       ...(config.options?.search_view_title
         ? { search_view_title: config.options.search_view_title }
+        : {}),
+      ...(config.options?.volume_trailing_button
+        ? { volume_trailing_button: config.options.volume_trailing_button }
         : {}),
       use_experimental_lms_media_browser:
         config.options?.use_experimental_lms_media_browser ?? false,

--- a/src/utils/getMediocreMassiveLegacyConfigToMultiConfig.ts
+++ b/src/utils/getMediocreMassiveLegacyConfigToMultiConfig.ts
@@ -17,6 +17,8 @@ export const getMediocreMassiveLegacyConfigToMediocreMultiConfig = (
       lms_entity_id: config.lms_entity_id,
       search: config.search,
       media_browser: config.media_browser,
+      volume_trailing_button_custom_button:
+        config.volume_trailing_button_custom_button,
       custom_buttons: config.custom_buttons,
       can_be_grouped: true,
     },
@@ -75,6 +77,9 @@ export const getMediocreMassiveLegacyConfigToMediocreMultiConfig = (
         : {}),
       ...(config.options?.search_view_title
         ? { search_view_title: config.options.search_view_title }
+        : {}),
+      ...(config.options?.volume_trailing_button
+        ? { volume_trailing_button: config.options.volume_trailing_button }
         : {}),
       use_experimental_lms_media_browser:
         config.options?.use_experimental_lms_media_browser ?? false,

--- a/src/utils/getMediocreMassiveLegacyConfigToMultiConfig.ts
+++ b/src/utils/getMediocreMassiveLegacyConfigToMultiConfig.ts
@@ -62,6 +62,20 @@ export const getMediocreMassiveLegacyConfigToMediocreMultiConfig = (
         config.mode === "panel" ||
         config.mode === "in-card" ||
         config.mode === "popup",
+      always_show_footer_more_actions:
+        config.options?.always_show_footer_more_actions ?? false,
+      ...(config.options?.media_browser_view_icon
+        ? { media_browser_view_icon: config.options.media_browser_view_icon }
+        : {}),
+      ...(config.options?.media_browser_view_title
+        ? { media_browser_view_title: config.options.media_browser_view_title }
+        : {}),
+      ...(config.options?.player_view_icon
+        ? { player_view_icon: config.options.player_view_icon }
+        : {}),
+      ...(config.options?.search_view_title
+        ? { search_view_title: config.options.search_view_title }
+        : {}),
       use_experimental_lms_media_browser:
         config.options?.use_experimental_lms_media_browser ?? false,
     },

--- a/src/utils/getMultiConfigToMediocreMassiveConfig.test.ts
+++ b/src/utils/getMultiConfigToMediocreMassiveConfig.test.ts
@@ -101,10 +101,12 @@ describe("getMultiConfigToMediocreMassiveConfig", () => {
           ],
         },
         options: {
+          always_show_footer_more_actions: false,
           show_volume_step_buttons: true,
           use_volume_up_down_for_step_buttons: false,
           use_experimental_lms_media_browser: false,
         },
+        volume_trailing_button_custom_button: undefined,
       })
     );
   });
@@ -171,6 +173,7 @@ describe("getMultiConfigToMediocreMassiveConfig", () => {
       "panel"
     );
     expect(result.options).toEqual({
+      always_show_footer_more_actions: false,
       show_volume_step_buttons: false,
       use_volume_up_down_for_step_buttons: false,
       use_experimental_lms_media_browser: false,

--- a/src/utils/getMultiConfigToMediocreMassiveConfig.ts
+++ b/src/utils/getMultiConfigToMediocreMassiveConfig.ts
@@ -33,6 +33,8 @@ export const getMultiConfigToMediocreMassiveConfig = (
     lms_entity_id: selectedPlayer.lms_entity_id,
     search: selectedPlayer.search,
     media_browser: selectedPlayer.media_browser,
+    volume_trailing_button_custom_button:
+      selectedPlayer.volume_trailing_button_custom_button,
     custom_buttons: selectedPlayer.custom_buttons,
     mode: mode,
     speaker_group:
@@ -51,6 +53,9 @@ export const getMultiConfigToMediocreMassiveConfig = (
         : {}),
       ...(config.options?.search_view_title
         ? { search_view_title: config.options.search_view_title }
+        : {}),
+      ...(config.options?.volume_trailing_button
+        ? { volume_trailing_button: config.options.volume_trailing_button }
         : {}),
       show_volume_step_buttons:
         config.options?.show_volume_step_buttons ?? false,

--- a/src/utils/getMultiConfigToMediocreMassiveConfig.ts
+++ b/src/utils/getMultiConfigToMediocreMassiveConfig.ts
@@ -38,6 +38,20 @@ export const getMultiConfigToMediocreMassiveConfig = (
     speaker_group:
       speaker_group.entities.length > 1 ? speaker_group : undefined,
     options: {
+      always_show_footer_more_actions:
+        config.options?.always_show_footer_more_actions ?? false,
+      ...(config.options?.media_browser_view_icon
+        ? { media_browser_view_icon: config.options.media_browser_view_icon }
+        : {}),
+      ...(config.options?.media_browser_view_title
+        ? { media_browser_view_title: config.options.media_browser_view_title }
+        : {}),
+      ...(config.options?.player_view_icon
+        ? { player_view_icon: config.options.player_view_icon }
+        : {}),
+      ...(config.options?.search_view_title
+        ? { search_view_title: config.options.search_view_title }
+        : {}),
       show_volume_step_buttons:
         config.options?.show_volume_step_buttons ?? false,
       use_volume_up_down_for_step_buttons:

--- a/src/utils/getResolvedMultiMediaPlayer.test.ts
+++ b/src/utils/getResolvedMultiMediaPlayer.test.ts
@@ -1,0 +1,51 @@
+import { MediocreMultiMediaPlayerCardConfig } from "@types";
+import { getResolvedMultiMediaPlayer } from "./getResolvedMultiMediaPlayer";
+
+describe("getResolvedMultiMediaPlayer", () => {
+  it("falls back to root media_browser when the player does not define one", () => {
+    const config = {
+      media_browser: [
+        {
+          entity_id: "media_player.shared_browser",
+          name: "Shared Browser",
+          media_types: [{ media_type: "artists" }, { media_type: "albums" }],
+        },
+      ],
+    } as Pick<MediocreMultiMediaPlayerCardConfig, "media_browser">;
+
+    const player = {
+      entity_id: "media_player.kitchen",
+      name: "Kitchen",
+    };
+
+    expect(getResolvedMultiMediaPlayer(config, player)).toEqual({
+      ...player,
+      media_browser: config.media_browser,
+    });
+  });
+
+  it("keeps the player's own media_browser when present", () => {
+    const config = {
+      media_browser: [
+        {
+          entity_id: "media_player.shared_browser",
+          name: "Shared Browser",
+        },
+      ],
+    } as Pick<MediocreMultiMediaPlayerCardConfig, "media_browser">;
+
+    const player = {
+      entity_id: "media_player.office",
+      name: "Office",
+      media_browser: [
+        {
+          entity_id: "media_player.office_browser",
+          name: "Office Browser",
+          media_types: [{ media_type: "tracks" }],
+        },
+      ],
+    };
+
+    expect(getResolvedMultiMediaPlayer(config, player)).toEqual(player);
+  });
+});

--- a/src/utils/getResolvedMultiMediaPlayer.ts
+++ b/src/utils/getResolvedMultiMediaPlayer.ts
@@ -1,0 +1,15 @@
+import { MediocreMultiMediaPlayer, MediocreMultiMediaPlayerCardConfig } from "@types";
+
+export const getResolvedMultiMediaPlayer = (
+  config: Pick<MediocreMultiMediaPlayerCardConfig, "media_browser">,
+  player?: MediocreMultiMediaPlayer
+): MediocreMultiMediaPlayer | undefined => {
+  if (!player) {
+    return undefined;
+  }
+
+  return {
+    ...player,
+    media_browser: player.media_browser ?? config.media_browser,
+  };
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -17,6 +17,7 @@ export * from "./getIsDarkMode";
 export * from "./getIsLmsPlayer";
 export * from "./getIsMassPlayer";
 export * from "./getMediaBrowserEntryArray";
+export * from "./getResolvedMultiMediaPlayer";
 export * from "./getMediaPlayerTitleAndSubtitle";
 export * from "./getMediocreLegacyConfigToMultiConfig";
 export * from "./getMultiConfigToMediocreMassiveConfig";


### PR DESCRIPTION
## Summary

This PR makes the button to the right of the large player view's volume slider configurable.

It adds a small trailing-button system for the large volume row with three supported modes:

- `power`
- `custom`
- `none`

This is intentionally a narrow foundational PR built on top of PR 2.

## Why

On the current large player view, the control to the right of the volume slider is always a power button.

That is a sensible default, but it is also quite rigid:

- some setups want a custom action there instead
- some setups do not want a trailing button there at all
- later features like Music Assistant favorites or grouped-volume actions need a clean, explicit slot to build on

This PR does not try to solve all of those later use cases yet. It just turns that hardcoded trailing control into a small, configurable system while preserving today's default behavior.

## What changed

### New option: `volume_trailing_button`

Supported values in this PR:

- `power`
- `custom`
- `none`

Example:

```yaml
options:
  volume_trailing_button: custom

**New per-player field: volume_trailing_button_custom_button**
When volume_trailing_button: custom is selected, the chosen player can provide the button definition:

```media_players:
  - entity_id: media_player.living_room
    volume_trailing_button_custom_button:
      icon: mdi:heart
      name: Favorite
      tap_action:
        action: toggle
```
This uses the same **CustomButton** shape the card already uses for custom_buttons[]

So the mental model is:
- custom_buttons[] adds buttons to the custom-buttons area
- volume_trailing_button_custom_button adds one button specifically to the right side of the large volume row

Default behavior is preserved
If volume_trailing_button is omitted, the large player view still shows the existing power button.

That means existing cards do not need any YAML changes.

