### PR TITLE
feat: add Music Assistant stateful favorite control on Artwork PR2

### DIFF
--- a/docs/PR_02_MA_ARTWORK_FAVORITE.md
+++ b/docs/PR_02_MA_ARTWORK_FAVORITE.md
@@ -39,10 +39,15 @@ This PR turns that into a real artwork control while staying inside the boundari
 Supported fields in this PR:
 
 - `show_on_artwork`
+  - enables the artwork overlay button
 - `favorite_button_size`
+  - `small | medium | large`
 - `favorite_button_offset`
+  - one CSS offset value or two values as `x y`
 - `active_color`
+  - icon color when the current item is favorited
 - `inactive_color`
+  - icon color when the current item is not favorited
 
 Example:
 
@@ -83,6 +88,31 @@ That means:
 - multi card editor: per-player under `Music Assistant Integration (optional)`
 
 The artwork-specific controls only appear where there is actually a large artwork surface to place them on.
+
+In practice:
+
+- regular card: available when the card uses popup artwork
+- massive card: available directly
+- multi card: available for large cards
+
+The controls were kept in the MA section on purpose because this is not generic footer/UI customization. It depends on:
+
+- `ma_entity_id`
+- `ma_favorite_button_entity_id`
+- MA queue behavior
+
+### New runtime pieces
+
+This PR adds a dedicated runtime path for the artwork control:
+
+- `MaFavoriteButton`
+- `useMaFavoriteControl`
+
+Why:
+
+- keep the favorite logic isolated from the rest of the artwork/player rendering
+- keep MA-specific edge cases in one place
+- avoid leaking this behavior into unrelated generic button code
 
 ## How the two-way favorite behavior works
 
@@ -133,6 +163,19 @@ and then keeps a very small local override layer so that:
 - the visual state settles back to the real queue state once MA/HA reports it
 
 This ended up being the most reliable compromise without introducing a large custom state machine.
+
+The final behavior is intentionally modest:
+
+- local click sets a short-lived rendered override
+- Home Assistant `call_service` events for favorite/unfavorite also update that rendered override
+- the queue-reported state remains the long-term source of truth
+- a lightweight background refresh remains enabled so multiple open dashboards can converge even when they are otherwise idle
+
+This was the simplest model that still behaved well in testing across:
+
+- local clicks
+- two browser windows
+- Developer Tools manual service calls
 
 ## Important limitation: provider items vs library items
 
@@ -192,6 +235,28 @@ For provider items:
 
 This avoids broken backend errors in the UI and matches the current MA behavior more honestly.
 
+## User-facing behavior summary
+
+### When the current item is a library track
+
+- the star reflects current favorite state
+- clicking it favorites or unfavorites immediately
+- the state should sync quickly across open dashboards
+
+### When the current item is a provider-backed track
+
+- the star can still be used to favorite the track
+- the card warns that the favorite may take time to appear
+- unfavorite is intentionally blocked until MA exposes the track as a library item
+
+### When MA favorite config is missing
+
+If any of the required MA pieces are missing:
+
+- no artwork favorite button is shown
+
+That means the feature remains fully opt-in.
+
 ## Related MA discussion / docs
 
 Useful references for this behavior:
@@ -237,6 +302,15 @@ media_players:
       favorite_button_size: medium
       favorite_button_offset: 24px 14px
 ```
+
+## Screenshots
+
+Suggested screenshots to include in the PR:
+
+- editor screenshot showing the Music Assistant configuration section and artwork favorite controls
+- runtime screenshot showing the favorite button on artwork
+
+Those two images should make the PR much easier to scan quickly.
 
 ## Compatibility
 

--- a/docs/PR_02_MA_ARTWORK_FAVORITE.md
+++ b/docs/PR_02_MA_ARTWORK_FAVORITE.md
@@ -1,0 +1,300 @@
+# PR 2: Music Assistant Artwork Favorite
+
+This document summarizes the second review-sized PR branch:
+
+- branch: `pr/02-ma-artwork-favorite`
+- base: `pr/01-view-and-footer-options`
+
+## Goal
+
+Keep this PR focused on one coherent Music Assistant feature:
+
+- add a configurable MA favorite control on the large player artwork
+- make that control work in both directions when MA exposes enough queue/library information
+- keep the editor/config shape small and MA-specific
+
+This PR intentionally does **not** include:
+
+- favorite controls in the large volume row
+- grouped volume work
+- MA Search / Library redesign
+- extra generic UI customization work
+
+## Why
+
+The card already supported `ma_favorite_button_entity_id`, but that was only a one-way action hidden behind extra actions.
+
+That left three gaps:
+
+- no visible favorite state on the main player surface
+- no clear way to remove a favorite from the same surface
+- no editor support for configuring the artwork placement/appearance
+
+This PR turns that into a real artwork control while staying inside the boundaries that Music Assistant and the Home Assistant integration currently expose.
+
+## What changed
+
+### New config block: `ma_favorite_control`
+
+Supported fields in this PR:
+
+- `show_on_artwork`
+- `favorite_button_size`
+- `favorite_button_offset`
+- `active_color`
+- `inactive_color`
+
+Example:
+
+```yaml
+ma_favorite_control:
+  show_on_artwork: true
+  favorite_button_size: medium
+  favorite_button_offset: 14px
+  active_color: "#f2c94c"
+  inactive_color: "#111111"
+```
+
+Offset behavior:
+
+- one value: applies to both axes
+- two values: `x y`
+- `x` is distance from the right edge
+- `y` is distance from the top edge
+
+Examples:
+
+```yaml
+favorite_button_offset: 14px
+```
+
+```yaml
+favorite_button_offset: 24px 14px
+```
+
+### Editor support
+
+The favorite control is configured inside the existing Music Assistant section, not under generic UI options.
+
+That means:
+
+- single card editor: under `Music Assistant Integration (optional)`
+- massive card editor: under `Music Assistant Integration (optional)`
+- multi card editor: per-player under `Music Assistant Integration (optional)`
+
+The artwork-specific controls only appear where there is actually a large artwork surface to place them on.
+
+## How the two-way favorite behavior works
+
+The working implementation ended up being:
+
+- read favorite state from `music_assistant.get_queue`
+- add favorite by pressing the HA-created MA favorite button entity
+- remove favorite via `mass_queue.unfavorite_current_item`
+
+In practice that means:
+
+### Add favorite
+
+The Home Assistant Music Assistant integration creates a dedicated button entity for "favorite current song".
+
+This PR uses:
+
+- `button.press`
+- target: `ma_favorite_button_entity_id`
+
+Reference:
+
+- Home Assistant Music Assistant integration: `Favorite current song button`
+  - https://www.home-assistant.io/integrations/music_assistant/
+
+### Remove favorite
+
+For removal, this PR uses the MA queue action:
+
+```yaml
+action: mass_queue.unfavorite_current_item
+data:
+  entity: media_player.my_ma_player
+```
+
+This is what makes the control genuinely two-way for tracks that Music Assistant is exposing as library-backed queue items.
+
+### State / refresh behavior
+
+The card reads the current favorite state from:
+
+- `music_assistant.get_queue`
+
+and then keeps a very small local override layer so that:
+
+- clicking the button responds immediately
+- Home Assistant Developer Tools actions show up immediately on open dashboards
+- the visual state settles back to the real queue state once MA/HA reports it
+
+This ended up being the most reliable compromise without introducing a large custom state machine.
+
+## Important limitation: provider items vs library items
+
+This PR needs to be explicit about a current Music Assistant limitation.
+
+Music Assistant favorites are library-backed.
+
+That means there is an important difference between:
+
+- `library://track/...`
+- provider URIs such as `spotify--...://track/...`
+
+### Library items
+
+If the current queue item is already a library item:
+
+- favorite works
+- unfavorite works
+- the control behaves like a real toggle
+
+### Non-library/provider items
+
+If the current queue item is still a provider item:
+
+- favoriting is allowed
+- unfavoriting is **not** allowed yet from this control
+
+Why:
+
+- Music Assistant favorites are a subset of the library
+- favoriting a non-library item first adds it to the MA library
+- that can require metadata work before the track becomes a stable library-backed item
+
+This is why some tracks may initially appear with provider URIs like:
+
+```text
+spotify--...://track/...
+```
+
+and only later show up as:
+
+```text
+library://track/...
+```
+
+Once the current item is library-backed, unfavorite becomes available.
+
+### User-facing behavior in this PR
+
+For provider items:
+
+- clicking the control when not favorited still sends the favorite action
+- the card shows:
+  - `For non-library items, favoriting may take a few minutes to appear.`
+- if the user tries to unfavorite a non-library item, the card shows:
+  - `Unfavorite is only available for library tracks.`
+
+This avoids broken backend errors in the UI and matches the current MA behavior more honestly.
+
+## Related MA discussion / docs
+
+Useful references for this behavior:
+
+- Home Assistant Music Assistant integration
+  - https://www.home-assistant.io/integrations/music_assistant/
+- Music Assistant discussion about favorite services / current-item favorite workflows
+  - https://github.com/orgs/music-assistant/discussions/1984
+- Music Assistant Spotify provider docs
+  - https://www.music-assistant.io/music-providers/spotify/
+
+The relevant MA behavior here is that favoriting a provider-backed item effectively turns into "add to library + favorite", which is why non-library items may not reflect instantly.
+
+## Example
+
+```yaml
+type: custom:mediocre-massive-media-player-card
+entity_id: media_player.ma_basement_sonos
+mode: card
+ma_entity_id: media_player.ma_basement_sonos
+ma_favorite_button_entity_id: button.ma_basement_favorite_current_song
+ma_favorite_control:
+  show_on_artwork: true
+  favorite_button_size: medium
+  favorite_button_offset: 14px
+  active_color: "#f2c94c"
+  inactive_color: "#111111"
+```
+
+For multi card usage:
+
+```yaml
+type: custom:mediocre-multi-media-player-card
+entity_id: media_player.ma_basement_sonos
+size: large
+mode: card
+media_players:
+  - entity_id: media_player.ma_basement_sonos
+    ma_entity_id: media_player.ma_basement_sonos
+    ma_favorite_button_entity_id: button.ma_basement_favorite_current_song
+    ma_favorite_control:
+      show_on_artwork: true
+      favorite_button_size: medium
+      favorite_button_offset: 24px 14px
+```
+
+## Compatibility
+
+This PR is additive and intentionally narrow.
+
+- existing cards do not need YAML changes
+- existing `ma_favorite_button_entity_id` behavior still works
+- if `ma_favorite_control` is omitted, nothing new is shown
+- the config is kept MA-specific rather than adding another generic UI customization layer
+
+## Scope
+
+Included here:
+
+- artwork favorite button
+- MA-specific config/editor support
+- two-way behavior for library-backed items
+- graceful provider-item handling
+
+Still out of scope:
+
+- favorite button on the volume row
+- grouped volume panel
+- larger MA Search / Library changes
+
+## Files changed
+
+Runtime/UI:
+
+- [AlbumArt.tsx](/g:/Documents/Code%202025/repos/mediocre-hass-media-player-cards/src/components/AlbumArt/AlbumArt.tsx)
+- [MassivePlaybackController.tsx](/g:/Documents/Code%202025/repos/mediocre-hass-media-player-cards/src/components/MassivePlaybackController/MassivePlaybackController.tsx)
+- [MaFavoriteButton.tsx](/g:/Documents/Code%202025/repos/mediocre-hass-media-player-cards/src/components/MaFavoriteButton/MaFavoriteButton.tsx)
+- [useMaFavoriteControl.ts](/g:/Documents/Code%202025/repos/mediocre-hass-media-player-cards/src/hooks/useMaFavoriteControl.ts)
+
+Editor/config plumbing:
+
+- [FieldGroupMaEntities.tsx](/g:/Documents/Code%202025/repos/mediocre-hass-media-player-cards/src/components/Form/components/FieldGroupMaEntities.tsx)
+- [MediocreMassiveMediaPlayerCardEditor.tsx](/g:/Documents/Code%202025/repos/mediocre-hass-media-player-cards/src/components/MediocreMassiveMediaPlayerCard/MediocreMassiveMediaPlayerCardEditor.tsx)
+- [MediocreMediaPlayerCardEditor.tsx](/g:/Documents/Code%202025/repos/mediocre-hass-media-player-cards/src/components/MediocreMediaPlayerCard/MediocreMediaPlayerCardEditor.tsx)
+- [MediocreMultiMediaPlayerCardEditor.tsx](/g:/Documents/Code%202025/repos/mediocre-hass-media-player-cards/src/components/MediocreMultiMediaPlayerCard/MediocreMultiMediaPlayerCardEditor.tsx)
+- [config.ts](/g:/Documents/Code%202025/repos/mediocre-hass-media-player-cards/src/types/config.ts)
+- [cardConfigUtils.ts](/g:/Documents/Code%202025/repos/mediocre-hass-media-player-cards/src/utils/cardConfigUtils.ts)
+- [getMediocreLegacyConfigToMultiConfig.ts](/g:/Documents/Code%202025/repos/mediocre-hass-media-player-cards/src/utils/getMediocreLegacyConfigToMultiConfig.ts)
+- [getMediocreMassiveLegacyConfigToMultiConfig.ts](/g:/Documents/Code%202025/repos/mediocre-hass-media-player-cards/src/utils/getMediocreMassiveLegacyConfigToMultiConfig.ts)
+- [getMultiConfigToMediocreMassiveConfig.ts](/g:/Documents/Code%202025/repos/mediocre-hass-media-player-cards/src/utils/getMultiConfigToMediocreMassiveConfig.ts)
+- [index.ts](/g:/Documents/Code%202025/repos/mediocre-hass-media-player-cards/src/components/index.ts)
+- [index.ts](/g:/Documents/Code%202025/repos/mediocre-hass-media-player-cards/src/hooks/index.ts)
+
+Tests:
+
+- [maFavoriteArtwork.config.test.ts](/g:/Documents/Code%202025/repos/mediocre-hass-media-player-cards/src/utils/maFavoriteArtwork.config.test.ts)
+
+## Validation
+
+Validated on this branch with:
+
+- `yarn tsc --noEmit`
+- `yarn test`
+- `yarn build`
+
+I also generated a `.gz` build artifact locally for Home Assistant testing.

--- a/src/components/AlbumArt/AlbumArt.tsx
+++ b/src/components/AlbumArt/AlbumArt.tsx
@@ -1,4 +1,4 @@
-import { Icon, IconSize, usePlayer } from "@components";
+import { Icon, IconSize, MaFavoriteButton, usePlayer } from "@components";
 import { fadeIn, theme } from "@constants";
 import { css } from "@emotion/react";
 import { getDeviceIcon, getSourceIcon } from "@utils";
@@ -11,6 +11,7 @@ export type AlbumArtProps = {
   borderRadius?: number;
   iconSize: IconSize;
   renderLongPressIndicator?: () => JSX.Element | null;
+  showMaFavoriteButton?: boolean;
 } & ButtonHTMLAttributes<HTMLButtonElement>;
 
 const styles = {
@@ -69,6 +70,7 @@ export const AlbumArt = ({
   borderRadius = 4,
   iconSize,
   renderLongPressIndicator,
+  showMaFavoriteButton = false,
   ...buttonProps
 }: AlbumArtProps) => {
   const player = usePlayer();
@@ -194,6 +196,7 @@ export const AlbumArt = ({
           </div>
         )}
       </div>
+      {showMaFavoriteButton && <MaFavoriteButton />}
       {renderLongPressIndicator && renderLongPressIndicator()}
     </button>
   );

--- a/src/components/Form/components/FieldGroupMaEntities.tsx
+++ b/src/components/Form/components/FieldGroupMaEntities.tsx
@@ -1,9 +1,19 @@
 import { withFieldGroup } from "../hooks/useAppForm";
 import { Fragment } from "preact/jsx-runtime";
+import { css } from "@emotion/react";
+import { Label, SubForm } from "@components";
+import { InputGroup } from "@components/FormElements";
 
 type MaEntitiesFields = {
   ma_entity_id?: string | null;
   ma_favorite_button_entity_id?: string | null;
+  ma_favorite_control?: {
+    show_on_artwork?: boolean | null;
+    favorite_button_size?: "small" | "medium" | "large";
+    favorite_button_offset?: string | null;
+    active_color?: string | null;
+    inactive_color?: string | null;
+  } | null;
 };
 
 const defaultValues: MaEntitiesFields = {
@@ -11,10 +21,74 @@ const defaultValues: MaEntitiesFields = {
   ma_favorite_button_entity_id: null,
 };
 
+const styles = {
+  helperText: css({
+    display: "block",
+    marginBottom: "12px",
+    opacity: 0.8,
+  }),
+  sectionIntro: css({
+    display: "block",
+    marginBottom: "12px",
+    opacity: 0.75,
+    lineHeight: 1.4,
+  }),
+  sizeRow: css({
+    maxWidth: "360px",
+    marginBottom: "16px",
+  }),
+  offsetRow: css({
+    marginBottom: "16px",
+  }),
+  toggleField: css({
+    marginBottom: "12px",
+  }),
+  fieldGrid: css({
+    display: "grid",
+    gridTemplateColumns: "repeat(2, minmax(0, 1fr))",
+    gap: "12px",
+    alignItems: "start",
+    "@media (max-width: 720px)": {
+      gridTemplateColumns: "1fr",
+    },
+  }),
+  fieldLabel: css({
+    display: "block",
+    marginBottom: "8px",
+    fontWeight: 500,
+  }),
+  select: css({
+    width: "100%",
+    minHeight: "56px",
+    padding: "0 16px",
+    borderRadius: "12px",
+    border: "1px solid rgba(0, 0, 0, 0.18)",
+    backgroundColor: "var(--card-background-color, #fff)",
+    color: "var(--primary-text-color)",
+    font: "inherit",
+    boxSizing: "border-box",
+    outline: "none",
+    ":focus": {
+      borderColor: "var(--primary-color)",
+      boxShadow: "0 0 0 1px var(--primary-color)",
+    },
+  }),
+};
+
 export const FieldGroupMaEntities = withFieldGroup({
   defaultValues,
-  props: {},
-  render: function Render({ group }) {
+  props: {
+    artworkFavoriteHelperText: "" as string | undefined,
+    showArtworkFavoriteControls: true,
+  },
+  render: function Render({
+    artworkFavoriteHelperText,
+    group,
+    showArtworkFavoriteControls,
+  }) {
+    const showArtworkFields =
+      group.state.values.ma_favorite_control?.show_on_artwork === true;
+
     return (
       <Fragment>
         <group.AppField
@@ -35,6 +109,81 @@ export const FieldGroupMaEntities = withFieldGroup({
             />
           )}
         />
+        {artworkFavoriteHelperText ? (
+          <Label css={styles.helperText}>{artworkFavoriteHelperText}</Label>
+        ) : null}
+        {showArtworkFavoriteControls ? (
+          <SubForm
+            title="Favorite Button on Artwork (optional)"
+            initiallyExpanded={showArtworkFields}
+          >
+            <Label css={styles.sectionIntro}>
+              Adds a Music Assistant favorite toggle to the artwork overlay in
+              the large or popup player view.
+            </Label>
+            <group.AppField
+              name="ma_favorite_control.show_on_artwork"
+              children={field => (
+                <div css={styles.toggleField}>
+                  <field.Toggle label="Show favorite button on artwork" />
+                </div>
+              )}
+            />
+            {showArtworkFields ? (
+              <Fragment>
+                <div css={styles.sizeRow}>
+                  <group.Field name="ma_favorite_control.favorite_button_size">
+                    {field => (
+                      <InputGroup>
+                        <Label css={styles.fieldLabel}>Button size</Label>
+                        <select
+                          css={styles.select}
+                          onChange={event =>
+                            field.handleChange(
+                              (event.target as HTMLSelectElement).value as
+                                | "small"
+                                | "medium"
+                                | "large"
+                            )
+                          }
+                          value={field.state.value ?? "small"}
+                        >
+                          <option value="small">Small</option>
+                          <option value="medium">Medium</option>
+                          <option value="large">Large</option>
+                        </select>
+                      </InputGroup>
+                    )}
+                  </group.Field>
+                </div>
+                <div css={styles.offsetRow}>
+                  <group.AppField
+                    name="ma_favorite_control.favorite_button_offset"
+                    children={field => (
+                      <field.Text label="Offset (14px or 24px 14px)" />
+                    )}
+                  />
+                </div>
+                <div css={styles.fieldGrid}>
+                  <group.AppField
+                    name="ma_favorite_control.active_color"
+                    children={field => (
+                      <field.Text label="Active color (default: #f2c94c)" />
+                    )}
+                  />
+                  <group.AppField
+                    name="ma_favorite_control.inactive_color"
+                    children={field => (
+                      <field.Text label="Inactive color (default: #111111)" />
+                    )}
+                  />
+                </div>
+              </Fragment>
+            ) : (
+              <Fragment />
+            )}
+          </SubForm>
+        ) : null}
       </Fragment>
     );
   },

--- a/src/components/MaFavoriteButton/MaFavoriteButton.tsx
+++ b/src/components/MaFavoriteButton/MaFavoriteButton.tsx
@@ -1,0 +1,211 @@
+import { css } from "@emotion/react";
+import { Spinner } from "@components/Spinner";
+import { JSX } from "preact";
+import { useMaFavoriteControl } from "@hooks";
+
+const NON_LIBRARY_FAVORITE_MESSAGE =
+  "For non-library items, favoriting may take a few minutes to appear.";
+const NON_LIBRARY_UNFAVORITE_MESSAGE =
+  "Unfavorite is only available for library tracks.";
+
+const styles = {
+  container: css({
+    position: "absolute",
+    zIndex: 2,
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "flex-end",
+    gap: 8,
+    pointerEvents: "none",
+  }),
+  root: css({
+    pointerEvents: "auto",
+    borderRadius: "999px",
+    boxShadow: "0 2px 10px rgba(0, 0, 0, 0.2)",
+    backdropFilter: "blur(6px)",
+    color: "var(--mmpc-ma-favorite-color)",
+    "@media (hover: hover)": {
+      "&:hover": {
+        backgroundColor: "var(--mmpc-ma-favorite-hover-background)",
+      },
+    },
+    transition: "opacity 120ms ease, transform 120ms ease",
+  }),
+  active: css({
+    backgroundColor: "rgba(20, 20, 20, 0.66)",
+    border: "1px solid rgba(255, 255, 255, 0.16)",
+  }),
+  inactive: css({
+    backgroundColor: "rgba(235, 235, 235, 0.5)",
+    border: "1px solid rgba(255, 255, 255, 0.45)",
+  }),
+  button: css({
+    position: "relative",
+    appearance: "none",
+    background: "none",
+    border: "none",
+    cursor: "pointer",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: "999px",
+    padding: 4,
+    minWidth: "var(--mmpc-ma-favorite-button-size)",
+    minHeight: "var(--mmpc-ma-favorite-button-size)",
+    color: "inherit",
+    touchAction: "manipulation",
+    "-webkit-tap-highlight-color": "transparent",
+    "> ha-icon": {
+      "--mdc-icon-size": "var(--mmpc-ma-favorite-button-size)",
+      width: "var(--mmpc-ma-favorite-button-size)",
+      height: "var(--mmpc-ma-favorite-button-size)",
+      display: "flex",
+      pointerEvents: "none",
+    },
+  }),
+  busyIcon: css({
+    opacity: 0.35,
+  }),
+  spinnerOverlay: css({
+    position: "absolute",
+    inset: 0,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    pointerEvents: "none",
+  }),
+};
+
+const fireHassNotification = (message: string) => {
+  document.body?.dispatchEvent(
+    new CustomEvent("hass-notification", {
+      bubbles: true,
+      composed: true,
+      detail: { message },
+    })
+  );
+};
+
+const getOffsetPosition = (offset: string) => {
+  const parts = offset
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean);
+  const [xOffset, yOffset] =
+    parts.length >= 2
+      ? [parts[0], parts[1]]
+      : [parts[0] || "14px", parts[0] || "14px"];
+
+  return {
+    right: xOffset,
+    top: yOffset,
+  };
+};
+
+const getButtonSize = (size: "small" | "medium" | "large") => {
+  switch (size) {
+    case "medium":
+      return 32;
+    case "large":
+      return 40;
+    case "small":
+    default:
+      return 24;
+  }
+};
+
+export const MaFavoriteButton = () => {
+  const {
+    activeColor,
+    enabled,
+    favoriteButtonOffset,
+    favoriteButtonSize,
+    inactiveColor,
+    isLibraryItem,
+    isFavorite,
+    isLoading,
+    toggleFavorite,
+    unsupportedMessage,
+  } = useMaFavoriteControl();
+
+  if (!enabled) return null;
+
+  const handleOnClick: JSX.MouseEventHandler<HTMLDivElement> = event => {
+    event.preventDefault();
+    event.stopPropagation();
+    if (isLoading) return;
+    if (!isLibraryItem && isFavorite) {
+      fireHassNotification(NON_LIBRARY_UNFAVORITE_MESSAGE);
+      return;
+    }
+    if (!isLibraryItem) {
+      fireHassNotification(NON_LIBRARY_FAVORITE_MESSAGE);
+    }
+    void toggleFavorite();
+  };
+
+  const handleOnKeyDown: JSX.KeyboardEventHandler<HTMLDivElement> = event => {
+    if (event.key !== "Enter" && event.key !== " ") return;
+    event.preventDefault();
+    event.stopPropagation();
+    if (isLoading) return;
+    if (!isLibraryItem && isFavorite) {
+      fireHassNotification(NON_LIBRARY_UNFAVORITE_MESSAGE);
+      return;
+    }
+    if (!isLibraryItem) {
+      fireHassNotification(NON_LIBRARY_FAVORITE_MESSAGE);
+    }
+    void toggleFavorite();
+  };
+
+  return (
+    <div
+      css={styles.container}
+      style={{
+        ...getOffsetPosition(favoriteButtonOffset),
+      }}
+    >
+      <div
+        aria-label={isFavorite ? "Remove favorite" : "Add favorite"}
+        aria-busy={isLoading}
+        css={[styles.root, isFavorite ? styles.active : styles.inactive]}
+        onClick={handleOnClick}
+        onKeyDown={handleOnKeyDown}
+        role="button"
+        style={{
+          "--mmpc-ma-favorite-button-size": `${getButtonSize(
+            favoriteButtonSize
+          )}px`,
+          "--mmpc-ma-favorite-color": isFavorite ? activeColor : inactiveColor,
+          "--mmpc-ma-favorite-hover-background": isFavorite
+            ? "rgba(20, 20, 20, 0.8)"
+            : "rgba(235, 235, 235, 0.62)",
+          "--icon-primary-color": isFavorite ? activeColor : inactiveColor,
+          color: isFavorite ? activeColor : inactiveColor,
+          cursor:
+            !isLibraryItem && isFavorite
+              ? "not-allowed"
+              : isLoading
+                ? "progress"
+                : "pointer",
+          opacity: isLoading ? 0.72 : 1,
+        }}
+        tabIndex={0}
+        title={unsupportedMessage}
+      >
+        <div css={styles.button}>
+          <ha-icon
+            css={isLoading ? styles.busyIcon : undefined}
+            icon={isFavorite ? "mdi:star" : "mdi:star-outline"}
+          />
+          {isLoading ? (
+            <div css={styles.spinnerOverlay}>
+              <Spinner size={favoriteButtonSize} />
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/MaFavoriteButton/index.ts
+++ b/src/components/MaFavoriteButton/index.ts
@@ -1,0 +1,1 @@
+export * from "./MaFavoriteButton";

--- a/src/components/MassivePlaybackController/MassivePlaybackController.tsx
+++ b/src/components/MassivePlaybackController/MassivePlaybackController.tsx
@@ -30,7 +30,12 @@ export const MassivePlaybackController = ({
 }: MassivePlaybackControllerProps) => {
   return (
     <div css={styles.root} className={className}>
-      <AlbumArt iconSize="x-large" borderRadius={8} {...artworkButtonProps} />
+      <AlbumArt
+        iconSize="x-large"
+        borderRadius={8}
+        showMaFavoriteButton={true}
+        {...artworkButtonProps}
+      />
       <Title />
       <Track />
       <PlaybackControls />

--- a/src/components/MediocreLargeMultiMediaPlayerCard/components/FooterActions.tsx
+++ b/src/components/MediocreLargeMultiMediaPlayerCard/components/FooterActions.tsx
@@ -67,7 +67,8 @@ export const FooterActions = memo<FooterActionsProps>(
     const hasSearch = getHasSearch(search, ma_entity_id);
     const hasMediaBrowser = getHasMediaBrowser(media_browser);
     const hasQueue = useCanDisplayQueue({ ma_entity_id, lms_entity_id });
-    const footerIcons = config.options?.ui?.footer_icons;
+    const footerIcons =
+      config.size === "large" ? config.options?.ui?.footer_icons : undefined;
     const getFooterIcon = (key: keyof typeof defaultFooterIcons) =>
       footerIcons?.[key]?.trim() || defaultFooterIcons[key];
 

--- a/src/components/MediocreLargeMultiMediaPlayerCard/components/FooterActions.tsx
+++ b/src/components/MediocreLargeMultiMediaPlayerCard/components/FooterActions.tsx
@@ -35,6 +35,12 @@ const styles = {
   }),
 };
 
+const defaultFooterIcons = {
+  player: "mdi:home",
+  search: "mdi:magnify",
+  media_browser: "mdi:folder-music",
+} as const;
+
 export type FooterActionsProps = {
   setNavigationRoute: (route: NavigationRoute) => void;
   navigationRoute: NavigationRoute;
@@ -61,6 +67,9 @@ export const FooterActions = memo<FooterActionsProps>(
     const hasSearch = getHasSearch(search, ma_entity_id);
     const hasMediaBrowser = getHasMediaBrowser(media_browser);
     const hasQueue = useCanDisplayQueue({ ma_entity_id, lms_entity_id });
+    const footerIcons = config.options?.ui?.footer_icons;
+    const getFooterIcon = (key: keyof typeof defaultFooterIcons) =>
+      footerIcons?.[key]?.trim() || defaultFooterIcons[key];
 
     if (config.size && config.size !== "large") return null;
 
@@ -71,7 +80,7 @@ export const FooterActions = memo<FooterActionsProps>(
         {!desktopMode && (
           <IconButton
             size="small"
-            icon={"mdi:home"}
+            icon={getFooterIcon("player")}
             onClick={() => setNavigationRoute("massive")}
             selected={navigationRoute === "massive"}
           />
@@ -79,7 +88,7 @@ export const FooterActions = memo<FooterActionsProps>(
         {hasSearch && (
           <IconButton
             size="small"
-            icon={"mdi:magnify"}
+            icon={getFooterIcon("search")}
             onClick={() => setNavigationRoute("search")}
             selected={navigationRoute === "search"}
           />
@@ -87,7 +96,7 @@ export const FooterActions = memo<FooterActionsProps>(
         {hasMediaBrowser && (
           <IconButton
             size="small"
-            icon={"mdi:folder-music"}
+            icon={getFooterIcon("media_browser")}
             onClick={() => setNavigationRoute("media-browser")}
             selected={navigationRoute === "media-browser"}
           />

--- a/src/components/MediocreMassiveMediaPlayerCard/MediocreMassiveMediaPlayerCardEditor.tsx
+++ b/src/components/MediocreMassiveMediaPlayerCard/MediocreMassiveMediaPlayerCardEditor.tsx
@@ -168,7 +168,8 @@ export const MediocreMassiveMediaPlayerCardEditor: FC<
         title="Music Assistant Configuration (optional)"
         error={
           getSubformError("ma_entity_id") ??
-          getSubformError("ma_favorite_button_entity_id")
+          getSubformError("ma_favorite_button_entity_id") ??
+          getSubformError("ma_favorite_control")
         }
       >
         <FieldGroupMaEntities
@@ -176,7 +177,10 @@ export const MediocreMassiveMediaPlayerCardEditor: FC<
           fields={{
             ma_entity_id: "ma_entity_id",
             ma_favorite_button_entity_id: "ma_favorite_button_entity_id",
+            ma_favorite_control: "ma_favorite_control",
           }}
+          artworkFavoriteHelperText={undefined}
+          showArtworkFavoriteControls={true}
         />
       </SubForm>
       <SubForm

--- a/src/components/MediocreMassiveMediaPlayerCard/MediocreMassiveMediaPlayerCardEditor.tsx
+++ b/src/components/MediocreMassiveMediaPlayerCard/MediocreMassiveMediaPlayerCardEditor.tsx
@@ -5,7 +5,7 @@ import {
 import { MediocreMassiveMediaPlayerCardConfig } from "@types";
 import { useCallback, useEffect } from "preact/hooks";
 import { useStore, ValidationErrorMap } from "@tanstack/react-form";
-import { FormGroup, SubForm, FormSelect } from "@components";
+import { FormGroup, SubForm, FormSelect, Label } from "@components";
 import { css } from "@emotion/react";
 import { FC } from "preact/compat";
 import {
@@ -219,6 +219,32 @@ export const MediocreMassiveMediaPlayerCardEditor: FC<
           formErrors={formErrorMap as ValidationErrorMap<unknown>}
           fields={{ custom_buttons: "custom_buttons" as never }} // todo this casting is stupid
         />
+      </SubForm>
+      <SubForm
+        title="UI Customization (optional)"
+        error={getSubformError("options.ui")}
+      >
+        <SubForm title="Footer / Navigation" error={getSubformError("options.ui.footer_icons")}>
+          <Label>Optional icon overrides for the large footer tabs.</Label>
+          <form.AppField
+            name="options.ui.footer_icons.player"
+            children={field => (
+              <field.Text label="Player / Home tab icon" isIconInput />
+            )}
+          />
+          <form.AppField
+            name="options.ui.footer_icons.search"
+            children={field => (
+              <field.Text label="Search tab icon" isIconInput />
+            )}
+          />
+          <form.AppField
+            name="options.ui.footer_icons.media_browser"
+            children={field => (
+              <field.Text label="Browse Media tab icon" isIconInput />
+            )}
+          />
+        </SubForm>
       </SubForm>
       <SubForm
         title="Additional options (optional)"

--- a/src/components/MediocreMediaPlayerCard/MediocreMediaPlayerCardEditor.tsx
+++ b/src/components/MediocreMediaPlayerCard/MediocreMediaPlayerCardEditor.tsx
@@ -64,6 +64,10 @@ export const MediocreMediaPlayerCardEditor: FC<
     },
   });
 
+  const tapOpensPopup = useStore(
+    form.store,
+    state => state.values.tap_opens_popup ?? false
+  );
   const formErrorMap = useStore(form.store, state => state.errorMap);
   const getSubformError = useCallback(
     (fieldName: string) => {
@@ -162,7 +166,8 @@ export const MediocreMediaPlayerCardEditor: FC<
         title="Music Assistant Configuration (optional)"
         error={
           getSubformError("ma_entity_id") ??
-          getSubformError("ma_favorite_button_entity_id")
+          getSubformError("ma_favorite_button_entity_id") ??
+          getSubformError("ma_favorite_control")
         }
       >
         <FieldGroupMaEntities
@@ -170,7 +175,14 @@ export const MediocreMediaPlayerCardEditor: FC<
           fields={{
             ma_entity_id: "ma_entity_id",
             ma_favorite_button_entity_id: "ma_favorite_button_entity_id",
+            ma_favorite_control: "ma_favorite_control",
           }}
+          showArtworkFavoriteControls={tapOpensPopup}
+          artworkFavoriteHelperText={
+            tapOpensPopup
+              ? "Shown on popup artwork."
+              : "Artwork favorite only appears on the popup artwork. Enable \"Tap opens popup\" to use it on this card."
+          }
         />
       </SubForm>
       <SubForm

--- a/src/components/MediocreMultiMediaPlayerCard/MediocreMultiMediaPlayerCardEditor.tsx
+++ b/src/components/MediocreMultiMediaPlayerCard/MediocreMultiMediaPlayerCardEditor.tsx
@@ -22,6 +22,7 @@ import { FieldGroupCustomButtons } from "@components/Form/components/FieldGroupC
 import { FieldGroupMaEntities } from "@components/Form/components/FieldGroupMaEntities";
 import { FieldGroupSearch } from "@components/Form/components/FieldGroupSearch";
 import { getSearchEntryArray } from "@utils/getSearchEntryArray";
+import { getCleanMaFavoriteControl } from "@utils/cardConfigUtils";
 
 export type MediocreMultiMediaPlayerCardEditorProps = {
   rootElement: HTMLElement;
@@ -117,7 +118,22 @@ export const MediocreMultiMediaPlayerCardEditor: FC<
         if (newConfig.search) {
           stripNulls(newConfig.search);
         }
-        if (newConfig.options?.ui?.footer_icons) {
+        newConfig.media_players = newConfig.media_players.map(
+          (player: MediocreMultiMediaPlayerCardConfig["media_players"][number]) => {
+          const maFavoriteControl = getCleanMaFavoriteControl(
+            player.ma_favorite_control
+          );
+          if (maFavoriteControl) {
+            return {
+              ...player,
+              ma_favorite_control: maFavoriteControl,
+            };
+          }
+          const { ma_favorite_control: _omit, ...rest } = player;
+          return rest;
+          }
+        );
+        if (newConfig.size === "large" && newConfig.options?.ui?.footer_icons) {
           Object.keys(newConfig.options.ui.footer_icons).forEach(key => {
             const icon =
               newConfig.options?.ui?.footer_icons?.[
@@ -135,6 +151,8 @@ export const MediocreMultiMediaPlayerCardEditor: FC<
           if (Object.keys(newConfig.options.ui).length === 0) {
             delete newConfig.options.ui;
           }
+        } else if (newConfig.options && "ui" in newConfig.options) {
+          delete (newConfig.options as { ui?: unknown }).ui;
         }
 
         if (formApi.state.isValid) {
@@ -150,10 +168,6 @@ export const MediocreMultiMediaPlayerCardEditor: FC<
   });
 
   const size = useStore(form.store, state => state.values.size);
-  const tapOpensPopup = useStore(form.store, state =>
-    "tap_opens_popup" in state.values ? state.values.tap_opens_popup : false
-  );
-
   const formErrorMap = useStore(form.store, state => state.errorMap);
   const getSubformError = useCallback(
     (fieldName: string) => {
@@ -316,6 +330,9 @@ export const MediocreMultiMediaPlayerCardEditor: FC<
                           ) ??
                           getSubformError(
                             `media_players[${index}].ma_favorite_button_entity_id`
+                          ) ??
+                          getSubformError(
+                            `media_players[${index}].ma_favorite_control`
                           )
                         }
                       >
@@ -324,7 +341,16 @@ export const MediocreMultiMediaPlayerCardEditor: FC<
                           fields={{
                             ma_entity_id: `media_players[${index}].ma_entity_id`,
                             ma_favorite_button_entity_id: `media_players[${index}].ma_favorite_button_entity_id`,
+                            ma_favorite_control: `media_players[${index}].ma_favorite_control`,
                           }}
+                          showArtworkFavoriteControls={
+                            size === "large"
+                          }
+                          artworkFavoriteHelperText={
+                            size === "large"
+                              ? undefined
+                              : "Artwork favorite only appears on large cards."
+                          }
                         />
                       </SubForm>
                       <SubForm
@@ -553,7 +579,7 @@ export const MediocreMultiMediaPlayerCardEditor: FC<
           </form.Field>
         </FormGroup>
       </SubForm>
-      {(size === "large" || tapOpensPopup) && (
+      {size === "large" && (
         <SubForm
           title="UI Customization (optional)"
           error={getSubformError("options.ui")}

--- a/src/components/MediocreMultiMediaPlayerCard/MediocreMultiMediaPlayerCardEditor.tsx
+++ b/src/components/MediocreMultiMediaPlayerCard/MediocreMultiMediaPlayerCardEditor.tsx
@@ -117,6 +117,25 @@ export const MediocreMultiMediaPlayerCardEditor: FC<
         if (newConfig.search) {
           stripNulls(newConfig.search);
         }
+        if (newConfig.options?.ui?.footer_icons) {
+          Object.keys(newConfig.options.ui.footer_icons).forEach(key => {
+            const icon =
+              newConfig.options?.ui?.footer_icons?.[
+                key as keyof typeof newConfig.options.ui.footer_icons
+              ];
+            if (!icon?.trim()) {
+              delete newConfig.options?.ui?.footer_icons?.[
+                key as keyof typeof newConfig.options.ui.footer_icons
+              ];
+            }
+          });
+          if (Object.keys(newConfig.options.ui.footer_icons).length === 0) {
+            delete newConfig.options.ui.footer_icons;
+          }
+          if (Object.keys(newConfig.options.ui).length === 0) {
+            delete newConfig.options.ui;
+          }
+        }
 
         if (formApi.state.isValid) {
           if (JSON.stringify(config) !== JSON.stringify(newConfig)) {
@@ -131,6 +150,9 @@ export const MediocreMultiMediaPlayerCardEditor: FC<
   });
 
   const size = useStore(form.store, state => state.values.size);
+  const tapOpensPopup = useStore(form.store, state =>
+    "tap_opens_popup" in state.values ? state.values.tap_opens_popup : false
+  );
 
   const formErrorMap = useStore(form.store, state => state.errorMap);
   const getSubformError = useCallback(
@@ -531,6 +553,37 @@ export const MediocreMultiMediaPlayerCardEditor: FC<
           </form.Field>
         </FormGroup>
       </SubForm>
+      {(size === "large" || tapOpensPopup) && (
+        <SubForm
+          title="UI Customization (optional)"
+          error={getSubformError("options.ui")}
+        >
+          <SubForm
+            title="Footer / Navigation"
+            error={getSubformError("options.ui.footer_icons")}
+          >
+            <Label>Optional icon overrides for the large footer tabs.</Label>
+            <form.AppField
+              name="options.ui.footer_icons.player"
+              children={field => (
+                <field.Text label="Player / Home tab icon" isIconInput />
+              )}
+            />
+            <form.AppField
+              name="options.ui.footer_icons.search"
+              children={field => (
+                <field.Text label="Search tab icon" isIconInput />
+              )}
+            />
+            <form.AppField
+              name="options.ui.footer_icons.media_browser"
+              children={field => (
+                <field.Text label="Browse Media tab icon" isIconInput />
+              )}
+            />
+          </SubForm>
+        </SubForm>
+      )}
     </form.AppForm>
   );
 };

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -16,6 +16,7 @@ export * from "./Input";
 export * from "./LyrionMediaBrowser";
 export * from "./MaSearch";
 export * from "./MassivePlaybackController";
+export * from "./MaFavoriteButton";
 export * from "./MediaBrowser";
 export * from "./MediaSearch";
 export * from "./MediocreChipMediaPlayerGroupCard";

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -3,6 +3,7 @@ export * from "./useArtworkColors";
 export * from "./useButtonCallbacks";
 export * from "./useCanDisplayQueue";
 export * from "./useHassMessagePromise";
+export * from "./useMaFavoriteControl";
 export * from "./useMassQueue";
 export * from "./useSqueezeboxQueue";
 export * from "./useSupportedFeatures";

--- a/src/hooks/useMaFavoriteControl.ts
+++ b/src/hooks/useMaFavoriteControl.ts
@@ -1,0 +1,286 @@
+import { useContext } from "preact/hooks";
+import { useCallback, useEffect, useMemo, useRef, useState } from "preact/hooks";
+import { CardContext, CardContextType } from "@components/CardContext";
+import { usePlayer } from "@components/PlayerContext";
+import { SelectedPlayerContext } from "@components/SelectedPlayerContext";
+import { getHasMassFeatures, getHass } from "@utils";
+import { useHassMessagePromise } from "./useHassMessagePromise";
+import type { MaFavoriteControl } from "@types";
+
+type MaFavoriteQueueResponse = Record<
+  string,
+  {
+    current_item?: {
+      queue_item_id?: string;
+      media_item?: {
+        favorite?: boolean;
+        uri?: string;
+      };
+    };
+  }
+>;
+
+type FavoriteAwareCardConfig = {
+  ma_entity_id?: string | null;
+  ma_favorite_button_entity_id?: string | null;
+  ma_favorite_control?: MaFavoriteControl;
+};
+
+const ENABLE_BACKGROUND_FAVORITE_POLLING = true;
+const FAVORITE_POLL_INTERVAL_MS = 10000;
+const CLICK_BUSY_DELAY_MS = 120;
+
+const matchesEntityId = (value: unknown, entityId: string) => {
+  if (typeof value === "string") {
+    return value === entityId;
+  }
+
+  if (Array.isArray(value)) {
+    return value.includes(entityId);
+  }
+
+  return false;
+};
+
+const sleep = (ms: number) =>
+  new Promise(resolve => window.setTimeout(resolve, ms));
+
+export const useMaFavoriteControl = () => {
+  const player = usePlayer();
+  const selectedPlayerContext = useContext(SelectedPlayerContext);
+  const { config } = useContext<CardContextType<FavoriteAwareCardConfig>>(
+    CardContext
+  );
+
+  const selectedPlayer = selectedPlayerContext?.selectedPlayer;
+  const maEntityId = selectedPlayer?.ma_entity_id ?? config.ma_entity_id;
+  const favoriteButtonEntityId =
+    selectedPlayer?.ma_favorite_button_entity_id ??
+    config.ma_favorite_button_entity_id;
+  const controlConfig =
+    selectedPlayer?.ma_favorite_control ?? config.ma_favorite_control;
+
+  const hasMassFeatures = getHasMassFeatures(
+    player.entity_id,
+    maEntityId ?? undefined
+  );
+  const enabled =
+    controlConfig?.show_on_artwork === true &&
+    hasMassFeatures &&
+    !!maEntityId &&
+    !!favoriteButtonEntityId;
+
+  const queueMessage = useMemo(
+    () =>
+      enabled
+        ? {
+            type: "call_service" as const,
+            domain: "music_assistant",
+            service: "get_queue",
+            service_data: {
+              entity_id: maEntityId,
+            },
+            return_response: true,
+          }
+        : null,
+    [enabled, maEntityId]
+  );
+
+  const queueQueryOptions = useMemo(
+    () => ({
+      enabled,
+      staleTime: 5000,
+    }),
+    [enabled]
+  );
+
+  const { data, refetch } =
+    useHassMessagePromise<MaFavoriteQueueResponse>(
+      queueMessage,
+      queueQueryOptions
+    );
+
+  const currentItem = maEntityId ? data?.[maEntityId]?.current_item : undefined;
+  const currentItemUri = currentItem?.media_item?.uri;
+  const backendFavorite = currentItem?.media_item?.favorite ?? false;
+  const isLibraryItem = !!currentItemUri?.startsWith("library://");
+
+  const [isToggling, setIsToggling] = useState(false);
+  const [overrideFavorite, setOverrideFavorite] = useState<boolean | null>(null);
+  const previousQueueFavoriteRef = useRef<boolean | null>(null);
+  const previousQueueItemIdRef = useRef<string | undefined>(undefined);
+
+  useEffect(() => {
+    if (
+      previousQueueItemIdRef.current &&
+      currentItem?.queue_item_id !== previousQueueItemIdRef.current
+    ) {
+      setOverrideFavorite(null);
+    }
+
+    previousQueueItemIdRef.current = currentItem?.queue_item_id;
+  }, [currentItem?.queue_item_id]);
+
+  useEffect(() => {
+    if (
+      previousQueueFavoriteRef.current !== null &&
+      previousQueueFavoriteRef.current !== backendFavorite
+    ) {
+      setOverrideFavorite(null);
+    }
+
+    previousQueueFavoriteRef.current = backendFavorite;
+  }, [backendFavorite]);
+
+  const refreshFavorite = useCallback(async () => {
+    await refetch();
+  }, [refetch]);
+
+  useEffect(() => {
+    if (!enabled) return;
+    void refreshFavorite();
+  }, [
+    enabled,
+    player.attributes.media_content_id,
+    player.attributes.media_title,
+    player.attributes.media_artist,
+    refreshFavorite,
+  ]);
+
+  useEffect(() => {
+    if (!ENABLE_BACKGROUND_FAVORITE_POLLING || !enabled || isToggling) {
+      return;
+    }
+
+    const intervalId = window.setInterval(() => {
+      void refreshFavorite();
+    }, FAVORITE_POLL_INTERVAL_MS);
+
+    return () => window.clearInterval(intervalId);
+  }, [enabled, isToggling, refreshFavorite]);
+
+  useEffect(() => {
+    if (!enabled || !maEntityId || !favoriteButtonEntityId) {
+      return;
+    }
+
+    let unsubscribe: (() => void) | undefined;
+    let cancelled = false;
+
+    const subscribeToFavoriteEvents = async () => {
+      unsubscribe = await getHass().connection.subscribeEvents(
+        (event: {
+          data?: {
+            domain?: string;
+            service?: string;
+            service_data?: {
+              entity?: unknown;
+              entity_id?: unknown;
+            };
+          };
+        }) => {
+          const domain = event.data?.domain;
+          const service = event.data?.service;
+          const serviceData = event.data?.service_data;
+
+          const favoriteButtonPressed =
+            domain === "button" &&
+            service === "press" &&
+            matchesEntityId(serviceData?.entity_id, favoriteButtonEntityId);
+
+          const queueUnfavorited =
+            domain === "mass_queue" &&
+            service === "unfavorite_current_item" &&
+            matchesEntityId(serviceData?.entity, maEntityId);
+
+          if (!favoriteButtonPressed && !queueUnfavorited) {
+            return;
+          }
+
+          setOverrideFavorite(favoriteButtonPressed);
+          void refreshFavorite();
+        },
+        "call_service"
+      );
+
+      if (cancelled && unsubscribe) {
+        unsubscribe();
+      }
+    };
+
+    void subscribeToFavoriteEvents();
+
+    return () => {
+      cancelled = true;
+      unsubscribe?.();
+    };
+  }, [enabled, favoriteButtonEntityId, maEntityId, refreshFavorite]);
+
+  const toggleFavorite = useCallback(async () => {
+    if (!enabled || !maEntityId || !favoriteButtonEntityId || isToggling) {
+      return;
+    }
+
+    const shouldFavorite = !(overrideFavorite ?? backendFavorite);
+
+    setIsToggling(true);
+    setOverrideFavorite(shouldFavorite);
+
+    try {
+      await sleep(CLICK_BUSY_DELAY_MS);
+
+      if (shouldFavorite) {
+        await getHass().callService("button", "press", {
+          entity_id: favoriteButtonEntityId,
+        });
+      } else {
+        await getHass().callService("mass_queue", "unfavorite_current_item", {
+          entity: maEntityId,
+        });
+      }
+
+      await refreshFavorite();
+    } finally {
+      setIsToggling(false);
+    }
+  }, [
+    backendFavorite,
+    enabled,
+    favoriteButtonEntityId,
+    isToggling,
+    maEntityId,
+    overrideFavorite,
+    refreshFavorite,
+  ]);
+
+  return useMemo(
+    () => ({
+      activeColor: controlConfig?.active_color?.trim() || "#f2c94c",
+      enabled,
+      favoriteButtonOffset:
+        controlConfig?.favorite_button_offset?.trim() || "14px",
+      favoriteButtonSize: controlConfig?.favorite_button_size ?? "small",
+      isLibraryItem,
+      inactiveColor: controlConfig?.inactive_color?.trim() || "#111111",
+      isFavorite: overrideFavorite ?? backendFavorite,
+      isLoading: isToggling,
+      toggleFavorite,
+      unsupportedMessage:
+        !isLibraryItem && (overrideFavorite ?? backendFavorite)
+          ? "Unfavorite is only available for library tracks."
+          : undefined,
+    }),
+    [
+      backendFavorite,
+      controlConfig?.active_color,
+      controlConfig?.favorite_button_offset,
+      controlConfig?.favorite_button_size,
+      controlConfig?.inactive_color,
+      enabled,
+      isLibraryItem,
+      isToggling,
+      overrideFavorite,
+      toggleFavorite,
+    ]
+  );
+};

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -11,9 +11,16 @@ const uiCustomizationSchema = type({
   "footer_icons?": footerIconsSchema, // Override footer/navigation tab icons
 });
 
+const maFavoriteControlSchema = type({
+  "show_on_artwork?": "boolean | null",
+  "favorite_button_size?": "'small' | 'medium' | 'large'",
+  "favorite_button_offset?": "string",
+  "active_color?": "string",
+  "inactive_color?": "string",
+});
+
 const commonMediocreMediaPlayerCardConfigOptionsSchema = type({
   "always_show_power_button?": "boolean | null", // Always show the power button, even if the media player is on
-  "ui?": uiCustomizationSchema, // UI customization overrides
   "show_volume_step_buttons?": "boolean", // Show volume step buttons + - on volume sliders
   "use_volume_up_down_for_step_buttons?": "boolean", // Use volume_up and volume_down services for step buttons instead of setting volume using set_volume. This breaks volume sync when step buttons are used.
   "use_experimental_lms_media_browser?": "boolean", // Use the experimental LMS media browser instead of the default one when an LMS entity is used and lyrion_cli integration is present.
@@ -80,6 +87,7 @@ const commonMediocreMediaPlayerCardConfigSchema = type({
   "custom_buttons?": customButtons,
   "ma_entity_id?": type("string").or("null").or("undefined"), // MusicAssistant entity_id (adds MA specific features (currently search))
   "ma_favorite_button_entity_id?": type("string").or("null").or("undefined"), // MusicAssistant button entity to mark current song as favorite
+  "ma_favorite_control?": maFavoriteControlSchema,
   "lms_entity_id?": type("string").or("null").or("undefined"), // LMS entity_id (adds LMS specific features)
   "search?": searchConfig,
   "media_browser?": mediaBrowser,
@@ -101,6 +109,9 @@ export const MediocreMediaPlayerCardConfigSchema =
 export const MediocreMassiveMediaPlayerCardConfigSchema =
   commonMediocreMediaPlayerCardConfigSchema.and({
     mode: "'panel'|'card'|'in-card'|'popup'", // don't document popup and multi as they are only for internal use
+    "options?": commonMediocreMediaPlayerCardConfigOptionsSchema.and({
+      "ui?": uiCustomizationSchema, // UI customization overrides
+    }),
   });
 
 export const MediocreMultiMediaPlayer = type({
@@ -111,6 +122,7 @@ export const MediocreMultiMediaPlayer = type({
   "can_be_grouped?": "boolean | null",
   "ma_entity_id?": type("string").or("null").or("undefined"), // MusicAssistant entity_id (adds MA specific features (currently search))
   "ma_favorite_button_entity_id?": type("string").or("null").or("undefined"), // MusicAssistant button entity to mark current song as favorite
+  "ma_favorite_control?": maFavoriteControlSchema,
   "lms_entity_id?": type("string").or("null").or("undefined"), // LMS entity_id (adds LMS specific features)
   "search?": searchConfig,
   "media_browser?": mediaBrowser,
@@ -119,7 +131,6 @@ export const MediocreMultiMediaPlayer = type({
 
 export const commonMediaPlayerCardOptions = type({
   "player_is_active_when?": "'playing' | 'playing_or_paused'", // When to consider a media player as active.
-  "ui?": uiCustomizationSchema, // UI customization overrides
   "show_volume_step_buttons?": "boolean", // Show volume step buttons + - on volume sliders
   "use_volume_up_down_for_step_buttons?": "boolean", // Use volume_up and volume_down services for step buttons instead of setting volume using set_volume. This breaks volume sync when step buttons are used.
   "use_experimental_lms_media_browser?": "boolean", // Use the experimental LMS media browser instead of the default one when an LMS entity is used and lyrion_cli integration is present.
@@ -143,6 +154,7 @@ export const MediocreMultiMediaPlayerCardConfigSchema =
       "height?": "number | string", // height of the card (can be a number in px or a string with any css unit)
       "options?": commonMediaPlayerCardOptions.and({
         "hide_selected_player_header?": "boolean", // Hide the header of the selected player in the massive view
+        "ui?": uiCustomizationSchema, // UI customization overrides
         "transparent_background_on_home?": "boolean", // Makes the background transparent when the showing the massive player
         "default_tab?":
           "'massive'|'search'|'media-browser'|'speaker-grouping'|'custom-buttons'|'queue'", // The tab to show by default when the card loads
@@ -162,6 +174,7 @@ export const MediocreMultiMediaPlayerCardConfigSchema =
   );
 
 export type SearchMediaType = typeof searchMediaTypeSchema.infer;
+export type MaFavoriteControl = typeof maFavoriteControlSchema.infer;
 export type CommonMediocreMediaPlayerCardConfig =
   typeof commonMediocreMediaPlayerCardConfigSchema.infer;
 export type MediocreMediaPlayerCardConfig =

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -1,8 +1,19 @@
 import { type } from "arktype";
 import { interactionConfigSchema } from "./actionTypes";
 
+const footerIconsSchema = type({
+  "player?": "string",
+  "search?": "string",
+  "media_browser?": "string",
+});
+
+const uiCustomizationSchema = type({
+  "footer_icons?": footerIconsSchema, // Override footer/navigation tab icons
+});
+
 const commonMediocreMediaPlayerCardConfigOptionsSchema = type({
   "always_show_power_button?": "boolean | null", // Always show the power button, even if the media player is on
+  "ui?": uiCustomizationSchema, // UI customization overrides
   "show_volume_step_buttons?": "boolean", // Show volume step buttons + - on volume sliders
   "use_volume_up_down_for_step_buttons?": "boolean", // Use volume_up and volume_down services for step buttons instead of setting volume using set_volume. This breaks volume sync when step buttons are used.
   "use_experimental_lms_media_browser?": "boolean", // Use the experimental LMS media browser instead of the default one when an LMS entity is used and lyrion_cli integration is present.
@@ -108,6 +119,7 @@ export const MediocreMultiMediaPlayer = type({
 
 export const commonMediaPlayerCardOptions = type({
   "player_is_active_when?": "'playing' | 'playing_or_paused'", // When to consider a media player as active.
+  "ui?": uiCustomizationSchema, // UI customization overrides
   "show_volume_step_buttons?": "boolean", // Show volume step buttons + - on volume sliders
   "use_volume_up_down_for_step_buttons?": "boolean", // Use volume_up and volume_down services for step buttons instead of setting volume using set_volume. This breaks volume sync when step buttons are used.
   "use_experimental_lms_media_browser?": "boolean", // Use the experimental LMS media browser instead of the default one when an LMS entity is used and lyrion_cli integration is present.

--- a/src/utils/cardConfigUtils.test.ts
+++ b/src/utils/cardConfigUtils.test.ts
@@ -126,6 +126,12 @@ describe("cardConfigUtils", () => {
           always_show_custom_buttons: true,
           hide_when_group_child: true,
           hide_when_off: true,
+          ui: {
+            footer_icons: {
+              player: "mdi:play-circle",
+              media_browser: "mdi:bookshelf",
+            },
+          },
           show_volume_step_buttons: true,
           use_volume_up_down_for_step_buttons: true,
           use_experimental_lms_media_browser: false,
@@ -363,6 +369,41 @@ describe("cardConfigUtils", () => {
         media_browser: { enabled: true },
       });
     });
+
+    it("should preserve non-empty footer icon overrides and drop empty ones", () => {
+      const configWithFooterIcons: MediocreMediaPlayerCardConfig = {
+        type: "custom:mediocre-media-player-card",
+        entity_id: "media_player.test",
+        use_art_colors: false,
+        tap_opens_popup: false,
+        action: {},
+        speaker_group: { entity_id: null, entities: [] },
+        search: { enabled: false, show_favorites: false, entity_id: null },
+        ma_entity_id: null,
+        custom_buttons: [],
+        options: {
+          always_show_power_button: false,
+          always_show_custom_buttons: false,
+          ui: {
+            footer_icons: {
+              player: "mdi:play",
+              search: " ",
+            },
+          },
+        },
+        media_browser: { enabled: false },
+      };
+
+      const result = getSimpleConfigFromFormValues(configWithFooterIcons);
+
+      expect(result.options).toEqual({
+        ui: {
+          footer_icons: {
+            player: "mdi:play",
+          },
+        },
+      });
+    });
   });
 
   describe("getSimpleConfigFromMassiveFormValues", () => {
@@ -448,6 +489,42 @@ describe("cardConfigUtils", () => {
         mode: "card",
         grid_options: { columns: "full" },
         media_browser: { enabled: true },
+      });
+    });
+
+    it("should preserve non-empty footer icon overrides and drop empty ones", () => {
+      const configWithFooterIcons: MediocreMassiveMediaPlayerCardConfig = {
+        type: "custom:mediocre-massive-media-player-card",
+        entity_id: "media_player.test",
+        mode: "card",
+        use_art_colors: false,
+        action: {},
+        speaker_group: { entity_id: null, entities: [] },
+        search: { enabled: false, show_favorites: false, entity_id: null },
+        ma_entity_id: null,
+        custom_buttons: [],
+        options: {
+          always_show_power_button: false,
+          ui: {
+            footer_icons: {
+              media_browser: "mdi:playlist-music",
+              search: "",
+            },
+          },
+        },
+        media_browser: { enabled: false },
+      };
+
+      const result = getSimpleConfigFromMassiveFormValues(
+        configWithFooterIcons
+      );
+
+      expect(result.options).toEqual({
+        ui: {
+          footer_icons: {
+            media_browser: "mdi:playlist-music",
+          },
+        },
       });
     });
   });

--- a/src/utils/cardConfigUtils.test.ts
+++ b/src/utils/cardConfigUtils.test.ts
@@ -126,12 +126,6 @@ describe("cardConfigUtils", () => {
           always_show_custom_buttons: true,
           hide_when_group_child: true,
           hide_when_off: true,
-          ui: {
-            footer_icons: {
-              player: "mdi:play-circle",
-              media_browser: "mdi:bookshelf",
-            },
-          },
           show_volume_step_buttons: true,
           use_volume_up_down_for_step_buttons: true,
           use_experimental_lms_media_browser: false,
@@ -370,40 +364,6 @@ describe("cardConfigUtils", () => {
       });
     });
 
-    it("should preserve non-empty footer icon overrides and drop empty ones", () => {
-      const configWithFooterIcons: MediocreMediaPlayerCardConfig = {
-        type: "custom:mediocre-media-player-card",
-        entity_id: "media_player.test",
-        use_art_colors: false,
-        tap_opens_popup: false,
-        action: {},
-        speaker_group: { entity_id: null, entities: [] },
-        search: { enabled: false, show_favorites: false, entity_id: null },
-        ma_entity_id: null,
-        custom_buttons: [],
-        options: {
-          always_show_power_button: false,
-          always_show_custom_buttons: false,
-          ui: {
-            footer_icons: {
-              player: "mdi:play",
-              search: " ",
-            },
-          },
-        },
-        media_browser: { enabled: false },
-      };
-
-      const result = getSimpleConfigFromFormValues(configWithFooterIcons);
-
-      expect(result.options).toEqual({
-        ui: {
-          footer_icons: {
-            player: "mdi:play",
-          },
-        },
-      });
-    });
   });
 
   describe("getSimpleConfigFromMassiveFormValues", () => {

--- a/src/utils/cardConfigUtils.ts
+++ b/src/utils/cardConfigUtils.ts
@@ -1,4 +1,5 @@
 import {
+  MaFavoriteControl,
   MediocreMediaPlayerCardConfig,
   MediocreMassiveMediaPlayerCardConfig,
 } from "@types";
@@ -12,6 +13,33 @@ const getCleanFooterIcons = (
   );
 
   return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+};
+
+export const getCleanMaFavoriteControl = (
+  control?: MaFavoriteControl | null
+): MaFavoriteControl | undefined => {
+  if (!control?.show_on_artwork) return undefined;
+
+  const activeColor = control.active_color?.trim();
+  const favoriteButtonOffset = control.favorite_button_offset?.trim();
+  const inactiveColor = control.inactive_color?.trim();
+
+  return {
+    show_on_artwork: true,
+    ...(control.favorite_button_size &&
+    control.favorite_button_size !== "small"
+      ? { favorite_button_size: control.favorite_button_size }
+      : {}),
+    ...(favoriteButtonOffset && favoriteButtonOffset !== "14px"
+      ? { favorite_button_offset: favoriteButtonOffset }
+      : {}),
+    ...(activeColor && activeColor !== "#f2c94c"
+      ? { active_color: activeColor }
+      : {}),
+    ...(inactiveColor && inactiveColor !== "#111111"
+      ? { inactive_color: inactiveColor }
+      : {}),
+  };
 };
 
 /**
@@ -38,6 +66,9 @@ export const getDefaultValuesFromConfig = (
     : null,
   ma_entity_id: config?.ma_entity_id ?? null,
   ma_favorite_button_entity_id: config?.ma_favorite_button_entity_id ?? null,
+  ...(config?.ma_favorite_control
+    ? { ma_favorite_control: { ...config.ma_favorite_control } }
+    : {}),
   lms_entity_id: config?.lms_entity_id ?? null,
   custom_buttons: config?.custom_buttons ?? [],
   options: {
@@ -51,15 +82,6 @@ export const getDefaultValuesFromConfig = (
       config?.options?.show_volume_step_buttons ?? false,
     use_volume_up_down_for_step_buttons:
       config?.options?.use_volume_up_down_for_step_buttons ?? false,
-    ...(config?.options?.ui?.footer_icons
-      ? {
-          ui: {
-            footer_icons: {
-              ...config.options.ui.footer_icons,
-            },
-          },
-        }
-      : {}),
     use_experimental_lms_media_browser:
       config?.options?.use_experimental_lms_media_browser ?? false,
   },
@@ -90,6 +112,9 @@ export const getDefaultValuesFromMassiveConfig = (
     : null,
   ma_entity_id: config?.ma_entity_id ?? null,
   ma_favorite_button_entity_id: config?.ma_favorite_button_entity_id ?? null,
+  ...(config?.ma_favorite_control
+    ? { ma_favorite_control: { ...config.ma_favorite_control } }
+    : {}),
   lms_entity_id: config?.lms_entity_id ?? null,
   custom_buttons: config?.custom_buttons ?? [],
   options: {
@@ -136,6 +161,12 @@ export const getSimpleConfigFromFormValues = (
   if (!config.ma_favorite_button_entity_id) {
     delete config.ma_favorite_button_entity_id;
   }
+  const maFavoriteControl = getCleanMaFavoriteControl(config.ma_favorite_control);
+  if (maFavoriteControl) {
+    config.ma_favorite_control = maFavoriteControl;
+  } else {
+    delete config.ma_favorite_control;
+  }
 
   if (!config.lms_entity_id) delete config.lms_entity_id;
   if (!config.custom_buttons || config.custom_buttons.length === 0)
@@ -173,25 +204,9 @@ export const getSimpleConfigFromFormValues = (
   if (config.options?.use_volume_up_down_for_step_buttons === false) {
     delete config.options.use_volume_up_down_for_step_buttons;
   }
-  const footerIcons = getCleanFooterIcons(config.options?.ui?.footer_icons);
-  if (footerIcons) {
-    config.options = {
-      ...config.options,
-      ui: {
-        ...config.options?.ui,
-        footer_icons: footerIcons,
-      },
-    };
-  } else if (config.options?.ui?.footer_icons) {
-    delete config.options.ui.footer_icons;
-  }
-  if (config.options?.ui && Object.keys(config.options.ui).length === 0) {
-    delete config.options.ui;
-  }
   if (config.options?.use_experimental_lms_media_browser === false) {
     delete config.options.use_experimental_lms_media_browser;
   }
-
   if (Object.keys(config.options ?? {}).length === 0) {
     delete config.options;
   }
@@ -226,6 +241,12 @@ export const getSimpleConfigFromMassiveFormValues = (
   // Only preserve ma_favorite_button_entity_id if it is a non-empty string
   if (!config.ma_favorite_button_entity_id) {
     delete config.ma_favorite_button_entity_id;
+  }
+  const maFavoriteControl = getCleanMaFavoriteControl(config.ma_favorite_control);
+  if (maFavoriteControl) {
+    config.ma_favorite_control = maFavoriteControl;
+  } else {
+    delete config.ma_favorite_control;
   }
 
   if (!config.lms_entity_id) delete config.lms_entity_id;

--- a/src/utils/cardConfigUtils.ts
+++ b/src/utils/cardConfigUtils.ts
@@ -4,6 +4,16 @@ import {
 } from "@types";
 import { getSearchEntryArray } from "./getSearchEntryArray";
 
+const getCleanFooterIcons = (
+  footerIcons?: Record<string, string | undefined>
+) => {
+  const entries = Object.entries(footerIcons ?? {}).filter(
+    ([, icon]) => !!icon?.trim()
+  );
+
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+};
+
 /**
  * Creates default values from a regular media player card config
  */
@@ -41,6 +51,15 @@ export const getDefaultValuesFromConfig = (
       config?.options?.show_volume_step_buttons ?? false,
     use_volume_up_down_for_step_buttons:
       config?.options?.use_volume_up_down_for_step_buttons ?? false,
+    ...(config?.options?.ui?.footer_icons
+      ? {
+          ui: {
+            footer_icons: {
+              ...config.options.ui.footer_icons,
+            },
+          },
+        }
+      : {}),
     use_experimental_lms_media_browser:
       config?.options?.use_experimental_lms_media_browser ?? false,
   },
@@ -80,6 +99,15 @@ export const getDefaultValuesFromMassiveConfig = (
       config?.options?.show_volume_step_buttons ?? false,
     use_volume_up_down_for_step_buttons:
       config?.options?.use_volume_up_down_for_step_buttons ?? false,
+    ...(config?.options?.ui?.footer_icons
+      ? {
+          ui: {
+            footer_icons: {
+              ...config.options.ui.footer_icons,
+            },
+          },
+        }
+      : {}),
     use_experimental_lms_media_browser:
       config?.options?.use_experimental_lms_media_browser ?? false,
   },
@@ -144,6 +172,21 @@ export const getSimpleConfigFromFormValues = (
   }
   if (config.options?.use_volume_up_down_for_step_buttons === false) {
     delete config.options.use_volume_up_down_for_step_buttons;
+  }
+  const footerIcons = getCleanFooterIcons(config.options?.ui?.footer_icons);
+  if (footerIcons) {
+    config.options = {
+      ...config.options,
+      ui: {
+        ...config.options?.ui,
+        footer_icons: footerIcons,
+      },
+    };
+  } else if (config.options?.ui?.footer_icons) {
+    delete config.options.ui.footer_icons;
+  }
+  if (config.options?.ui && Object.keys(config.options.ui).length === 0) {
+    delete config.options.ui;
   }
   if (config.options?.use_experimental_lms_media_browser === false) {
     delete config.options.use_experimental_lms_media_browser;
@@ -210,6 +253,21 @@ export const getSimpleConfigFromMassiveFormValues = (
   }
   if (config.options?.use_volume_up_down_for_step_buttons === false) {
     delete config.options.use_volume_up_down_for_step_buttons;
+  }
+  const footerIcons = getCleanFooterIcons(config.options?.ui?.footer_icons);
+  if (footerIcons) {
+    config.options = {
+      ...config.options,
+      ui: {
+        ...config.options?.ui,
+        footer_icons: footerIcons,
+      },
+    };
+  } else if (config.options?.ui?.footer_icons) {
+    delete config.options.ui.footer_icons;
+  }
+  if (config.options?.ui && Object.keys(config.options.ui).length === 0) {
+    delete config.options.ui;
   }
   if (config.options?.use_experimental_lms_media_browser === false) {
     delete config.options.use_experimental_lms_media_browser;

--- a/src/utils/getMediocreLegacyConfigToMultiConfig.test.ts
+++ b/src/utils/getMediocreLegacyConfigToMultiConfig.test.ts
@@ -43,12 +43,6 @@ describe("getMediocreLegacyConfigToMediocreMultiConfig", () => {
       always_show_power_button: false,
       hide_when_group_child: false,
       hide_when_off: false,
-      ui: {
-        footer_icons: {
-          player: "mdi:play-circle",
-          media_browser: "mdi:bookshelf",
-        },
-      },
     },
   };
 
@@ -69,12 +63,6 @@ describe("getMediocreLegacyConfigToMediocreMultiConfig", () => {
           always_show_power_button: false,
           hide_when_group_child: false,
           hide_when_off: false,
-          ui: {
-            footer_icons: {
-              player: "mdi:play-circle",
-              media_browser: "mdi:bookshelf",
-            },
-          },
         }),
         media_players: [
           expect.objectContaining({

--- a/src/utils/getMediocreLegacyConfigToMultiConfig.test.ts
+++ b/src/utils/getMediocreLegacyConfigToMultiConfig.test.ts
@@ -43,6 +43,12 @@ describe("getMediocreLegacyConfigToMediocreMultiConfig", () => {
       always_show_power_button: false,
       hide_when_group_child: false,
       hide_when_off: false,
+      ui: {
+        footer_icons: {
+          player: "mdi:play-circle",
+          media_browser: "mdi:bookshelf",
+        },
+      },
     },
   };
 
@@ -63,6 +69,12 @@ describe("getMediocreLegacyConfigToMediocreMultiConfig", () => {
           always_show_power_button: false,
           hide_when_group_child: false,
           hide_when_off: false,
+          ui: {
+            footer_icons: {
+              player: "mdi:play-circle",
+              media_browser: "mdi:bookshelf",
+            },
+          },
         }),
         media_players: [
           expect.objectContaining({

--- a/src/utils/getMediocreLegacyConfigToMultiConfig.ts
+++ b/src/utils/getMediocreLegacyConfigToMultiConfig.ts
@@ -57,6 +57,15 @@ export const getMediocreLegacyConfigToMediocreMultiConfig = (
         config.options?.show_volume_step_buttons ?? false,
       use_volume_up_down_for_step_buttons:
         config.options?.use_volume_up_down_for_step_buttons ?? false,
+      ...(config.options?.ui?.footer_icons
+        ? {
+            ui: {
+              footer_icons: {
+                ...config.options.ui.footer_icons,
+              },
+            },
+          }
+        : {}),
       always_show_custom_buttons:
         config.options?.always_show_custom_buttons ?? false,
       always_show_power_button:

--- a/src/utils/getMediocreLegacyConfigToMultiConfig.ts
+++ b/src/utils/getMediocreLegacyConfigToMultiConfig.ts
@@ -13,6 +13,7 @@ export const getMediocreLegacyConfigToMediocreMultiConfig = (
       entity_id: config.entity_id,
       ma_entity_id: config.ma_entity_id,
       ma_favorite_button_entity_id: config.ma_favorite_button_entity_id,
+      ma_favorite_control: config.ma_favorite_control,
       speaker_group_entity_id: config.speaker_group?.entity_id,
       lms_entity_id: config.lms_entity_id,
       search: config.search,
@@ -57,15 +58,6 @@ export const getMediocreLegacyConfigToMediocreMultiConfig = (
         config.options?.show_volume_step_buttons ?? false,
       use_volume_up_down_for_step_buttons:
         config.options?.use_volume_up_down_for_step_buttons ?? false,
-      ...(config.options?.ui?.footer_icons
-        ? {
-            ui: {
-              footer_icons: {
-                ...config.options.ui.footer_icons,
-              },
-            },
-          }
-        : {}),
       always_show_custom_buttons:
         config.options?.always_show_custom_buttons ?? false,
       always_show_power_button:

--- a/src/utils/getMediocreMassiveLegacyConfigToMultiConfig.ts
+++ b/src/utils/getMediocreMassiveLegacyConfigToMultiConfig.ts
@@ -58,6 +58,15 @@ export const getMediocreMassiveLegacyConfigToMediocreMultiConfig = (
         config.options?.show_volume_step_buttons ?? false,
       use_volume_up_down_for_step_buttons:
         config.options?.use_volume_up_down_for_step_buttons ?? false,
+      ...(config.options?.ui?.footer_icons
+        ? {
+            ui: {
+              footer_icons: {
+                ...config.options.ui.footer_icons,
+              },
+            },
+          }
+        : {}),
       transparent_background_on_home:
         config.mode === "panel" ||
         config.mode === "in-card" ||

--- a/src/utils/getMediocreMassiveLegacyConfigToMultiConfig.ts
+++ b/src/utils/getMediocreMassiveLegacyConfigToMultiConfig.ts
@@ -13,6 +13,7 @@ export const getMediocreMassiveLegacyConfigToMediocreMultiConfig = (
       entity_id: config.entity_id,
       ma_entity_id: config.ma_entity_id,
       ma_favorite_button_entity_id: config.ma_favorite_button_entity_id,
+      ma_favorite_control: config.ma_favorite_control,
       speaker_group_entity_id: config.speaker_group?.entity_id,
       lms_entity_id: config.lms_entity_id,
       search: config.search,

--- a/src/utils/getMultiConfigToMediocreMassiveConfig.test.ts
+++ b/src/utils/getMultiConfigToMediocreMassiveConfig.test.ts
@@ -51,6 +51,12 @@ describe("getMultiConfigToMediocreMassiveConfig", () => {
     options: {
       show_volume_step_buttons: true,
       use_volume_up_down_for_step_buttons: false,
+      ui: {
+        footer_icons: {
+          player: "mdi:play-circle",
+          media_browser: "mdi:playlist-music",
+        },
+      },
     },
     size: "large",
     mode: "panel",
@@ -103,6 +109,12 @@ describe("getMultiConfigToMediocreMassiveConfig", () => {
         options: {
           show_volume_step_buttons: true,
           use_volume_up_down_for_step_buttons: false,
+          ui: {
+            footer_icons: {
+              player: "mdi:play-circle",
+              media_browser: "mdi:playlist-music",
+            },
+          },
           use_experimental_lms_media_browser: false,
         },
       })

--- a/src/utils/getMultiConfigToMediocreMassiveConfig.ts
+++ b/src/utils/getMultiConfigToMediocreMassiveConfig.ts
@@ -42,6 +42,15 @@ export const getMultiConfigToMediocreMassiveConfig = (
         config.options?.show_volume_step_buttons ?? false,
       use_volume_up_down_for_step_buttons:
         config.options?.use_volume_up_down_for_step_buttons ?? false,
+      ...(config.options?.ui?.footer_icons
+        ? {
+            ui: {
+              footer_icons: {
+                ...config.options.ui.footer_icons,
+              },
+            },
+          }
+        : {}),
       use_experimental_lms_media_browser:
         config.options?.use_experimental_lms_media_browser ?? false,
     },

--- a/src/utils/getMultiConfigToMediocreMassiveConfig.ts
+++ b/src/utils/getMultiConfigToMediocreMassiveConfig.ts
@@ -8,6 +8,8 @@ export const getMultiConfigToMediocreMassiveConfig = (
   selectedPlayer: MediocreMultiMediaPlayerCardConfig["media_players"][number],
   mode: "panel" | "card" | "in-card" | "popup"
 ): MediocreMassiveMediaPlayerCardConfig => {
+  const footerIcons =
+    config.size === "large" ? config.options?.ui?.footer_icons : undefined;
   const speaker_group = {
     entity_id: selectedPlayer.speaker_group_entity_id,
     entities: config.media_players
@@ -30,6 +32,8 @@ export const getMultiConfigToMediocreMassiveConfig = (
     use_art_colors: config.use_art_colors,
     action: selectedPlayer.action,
     ma_entity_id: selectedPlayer.ma_entity_id,
+    ma_favorite_button_entity_id: selectedPlayer.ma_favorite_button_entity_id,
+    ma_favorite_control: selectedPlayer.ma_favorite_control,
     lms_entity_id: selectedPlayer.lms_entity_id,
     search: selectedPlayer.search,
     media_browser: selectedPlayer.media_browser,
@@ -42,11 +46,11 @@ export const getMultiConfigToMediocreMassiveConfig = (
         config.options?.show_volume_step_buttons ?? false,
       use_volume_up_down_for_step_buttons:
         config.options?.use_volume_up_down_for_step_buttons ?? false,
-      ...(config.options?.ui?.footer_icons
+      ...(footerIcons
         ? {
             ui: {
               footer_icons: {
-                ...config.options.ui.footer_icons,
+                ...footerIcons,
               },
             },
           }

--- a/src/utils/maFavoriteArtwork.config.test.ts
+++ b/src/utils/maFavoriteArtwork.config.test.ts
@@ -1,0 +1,136 @@
+import {
+  getDefaultValuesFromMassiveConfig,
+  getSimpleConfigFromMassiveFormValues,
+} from "@utils/cardConfigUtils";
+import { getMediocreLegacyConfigToMediocreMultiConfig } from "./getMediocreLegacyConfigToMultiConfig";
+import { getMediocreMassiveLegacyConfigToMediocreMultiConfig } from "./getMediocreMassiveLegacyConfigToMultiConfig";
+import { getMultiConfigToMediocreMassiveConfig } from "./getMultiConfigToMediocreMassiveConfig";
+import type {
+  MediocreMassiveMediaPlayerCardConfig,
+  MediocreMediaPlayerCardConfig,
+  MediocreMultiMediaPlayerCardConfig,
+} from "@types";
+
+describe("maFavoriteArtwork config plumbing", () => {
+  it("preserves MA favorite artwork fields in massive config defaults and cleanup", () => {
+    const config: MediocreMassiveMediaPlayerCardConfig = {
+      type: "custom:mediocre-massive-media-player-card",
+      entity_id: "media_player.test",
+      mode: "card",
+      ma_favorite_control: {
+        show_on_artwork: true,
+        favorite_button_size: "medium",
+        favorite_button_offset: "18px 24px",
+        active_color: "#ffd54f",
+        inactive_color: "#101010",
+      },
+    };
+
+    expect(getDefaultValuesFromMassiveConfig(config)).toEqual(
+      expect.objectContaining({
+        ma_favorite_control: {
+          show_on_artwork: true,
+          favorite_button_size: "medium",
+          favorite_button_offset: "18px 24px",
+          active_color: "#ffd54f",
+          inactive_color: "#101010",
+        },
+      })
+    );
+
+    expect(getSimpleConfigFromMassiveFormValues(config)).toEqual(
+      expect.objectContaining({
+        mode: "card",
+        ma_favorite_control: {
+          show_on_artwork: true,
+          favorite_button_size: "medium",
+          favorite_button_offset: "18px 24px",
+          active_color: "#ffd54f",
+          inactive_color: "#101010",
+        },
+      })
+    );
+  });
+
+  it("moves MA favorite artwork config from legacy regular card config to the first multi player", () => {
+    const config: MediocreMediaPlayerCardConfig = {
+      type: "custom:mediocre-media-player-card",
+      entity_id: "media_player.living_room",
+      ma_entity_id: "media_player.ma_living_room",
+      ma_favorite_button_entity_id: "button.favorite_current_song",
+      ma_favorite_control: {
+        show_on_artwork: true,
+        favorite_button_size: "medium",
+      },
+    };
+
+    const result = getMediocreLegacyConfigToMediocreMultiConfig(config);
+
+    expect(result.media_players[0].ma_favorite_control).toEqual({
+      show_on_artwork: true,
+      favorite_button_size: "medium",
+    });
+    expect(result.media_players[0].ma_favorite_button_entity_id).toBe(
+      "button.favorite_current_song"
+    );
+  });
+
+  it("moves MA favorite artwork config from legacy massive card config to the first multi player", () => {
+    const config: MediocreMassiveMediaPlayerCardConfig = {
+      type: "custom:mediocre-massive-media-player-card",
+      entity_id: "media_player.living_room",
+      mode: "card",
+      ma_entity_id: "media_player.ma_living_room",
+      ma_favorite_button_entity_id: "button.favorite_current_song",
+      ma_favorite_control: {
+        show_on_artwork: true,
+        favorite_button_offset: "22px 18px",
+      },
+    };
+
+    const result = getMediocreMassiveLegacyConfigToMediocreMultiConfig(config);
+
+    expect(result.media_players[0].ma_favorite_control).toEqual({
+      show_on_artwork: true,
+      favorite_button_offset: "22px 18px",
+    });
+    expect(result.media_players[0].ma_favorite_button_entity_id).toBe(
+      "button.favorite_current_song"
+    );
+  });
+
+  it("passes MA favorite artwork config from multi-card config to the derived massive config", () => {
+    const config: MediocreMultiMediaPlayerCardConfig = {
+      type: "custom:mediocre-multi-media-player-card",
+      entity_id: "media_player.living_room",
+      size: "large",
+      mode: "panel",
+      media_players: [
+        {
+          entity_id: "media_player.living_room",
+          can_be_grouped: true,
+          ma_entity_id: "media_player.ma_living_room",
+          ma_favorite_button_entity_id: "button.favorite_current_song",
+          ma_favorite_control: {
+            show_on_artwork: true,
+            favorite_button_offset: "20px 12px",
+          },
+        },
+      ],
+    };
+
+    const result = getMultiConfigToMediocreMassiveConfig(
+      config,
+      config.media_players[0],
+      "panel"
+    );
+
+    expect(result.ma_favorite_control).toEqual({
+      show_on_artwork: true,
+      favorite_button_offset: "20px 12px",
+    });
+    expect(result.ma_favorite_button_entity_id).toBe(
+      "button.favorite_current_song"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds a configurable Music Assistant favorite control to the artwork in the large player view.

It turns the existing `ma_favorite_button_entity_id` support into a real visible control with:

- MA-specific config
- editor support
- add favorite support
- unfavorite support for library-backed items
- graceful handling for provider-backed items that Music Assistant has not fully resolved into library items yet

This PR is intentionally focused on the artwork favorite control only.

## Why

The card already supported `ma_favorite_button_entity_id`, but that was only a one-way action hidden behind extra actions.

That left three gaps:

- no visible favorite state on the main player surface
- no clear way to remove a favorite from the same surface
- no editor support for configuring the artwork placement/appearance

This PR turns that into a real artwork control while staying inside the boundaries that Music Assistant and the Home Assistant integration currently expose.

<img width="1004" height="1114" alt="image" src="https://github.com/user-attachments/assets/5d5eb443-f781-434d-aa5b-97f26f474901" />



## What changed

### New config block: `ma_favorite_control` inside Music Assistant Integration

Supported fields in this PR:

- `show_on_artwork`
  - enables the artwork overlay button
- `favorite_button_size`
  - `small | medium | large`
- `favorite_button_offset`
  - one CSS offset value or two values as `x y`
- `active_color`
  - icon color when the current item is favorited
- `inactive_color`
  - icon color when the current item is not favorited

Example:

```yaml
ma_favorite_control:
  show_on_artwork: true
  favorite_button_size: medium
  favorite_button_offset: 14px
  active_color: "#f2c94c"
  inactive_color: "#111111"
```

### Editor support

The favorite control is configured inside the existing Music Assistant section, not under generic UI options.

That means:

- single card editor: under `Music Assistant Integration (optional)`
- massive card editor: under `Music Assistant Integration (optional)`
- multi card editor: per-player under `Music Assistant Integration (optional)`

The artwork-specific controls only appear where there is actually a large artwork surface to place them on.

<img width="934" height="1384" alt="image" src="https://github.com/user-attachments/assets/ecd3473f-1ffb-4dde-8d6a-ade25fb87908" />

The controls were kept in the MA section on purpose because this is not generic footer/UI customization. It depends on:

- `ma_entity_id`
- `ma_favorite_button_entity_id`
- MA queue behavior

### New runtime pieces

This PR adds a dedicated runtime path for the artwork control:

- `MaFavoriteButton`
- `useMaFavoriteControl`

Why:

- keep the favorite logic isolated from the rest of the artwork/player rendering
- keep MA-specific edge cases in one place
- avoid leaking this behavior into unrelated generic button code

## How the two-way favorite behavior works

The working implementation ended up being:

- read favorite state from `music_assistant.get_queue`
- add favorite by pressing the HA-created MA favorite button entity
- remove favorite via `mass_queue.unfavorite_current_item`

In practice that means:

### Add favorite

The Home Assistant Music Assistant integration creates a dedicated button entity for "favorite current song".

This PR uses:

- `button.press`
- target: `ma_favorite_button_entity_id`

### Remove favorite

For removal, this PR uses the MA queue action:

```yaml
action: mass_queue.unfavorite_current_item
data:
  entity: media_player.my_ma_player
```

This is what makes the control genuinely two-way for tracks that Music Assistant is exposing as library-backed queue items.

### State / refresh behavior

The card reads the current favorite state from:

- `music_assistant.get_queue`

and then keeps a very small local override layer so that:

- clicking the button responds immediately
- Home Assistant Developer Tools actions show up immediately on open dashboards
- the visual state settles back to the real queue state once MA/HA reports it

This ended up being the most reliable compromise without introducing a large custom state machine.

## Important limitation: provider items vs library items

This PR needs to be explicit about a current Music Assistant limitation.

Music Assistant favorites are library-backed.

That means there is an important difference between:

- `library://track/...`
- provider URIs such as `spotify--...://track/...`

### Library items

If the current queue item is already a library item - it just works.

### Non-library/provider items

If the current queue item is a provider item:

- favoriting is allowed -- but ma takes an extended period to convert the provider item into a library item
- unfavoriting is **not** allowed until that happens.

This is why some tracks may initially appear with provider URIs like:

```text
spotify--...://track/...
```

and only later show up as:

```text
library://track/...
```

see: https://github.com/music-assistant/support/issues/4948 for the background.

### When MA favorite config is missing

If any of the required MA pieces are missing:

- no artwork favorite button is shown

That means the feature remains fully opt-in.


## Example

```yaml
type: custom:mediocre-massive-media-player-card
entity_id: media_player.ma_basement_sonos
mode: card
ma_entity_id: media_player.ma_basement_sonos
ma_favorite_button_entity_id: button.ma_basement_favorite_current_song
ma_favorite_control:
  show_on_artwork: true
  favorite_button_size: medium
  favorite_button_offset: 14px
  active_color: "#f2c94c"
  inactive_color: "#111111"
```

For multi card usage:

```yaml
type: custom:mediocre-multi-media-player-card
entity_id: media_player.ma_basement_sonos
size: large
mode: card
media_players:
  - entity_id: media_player.ma_basement_sonos
    ma_entity_id: media_player.ma_basement_sonos
    ma_favorite_button_entity_id: button.ma_basement_favorite_current_song
    ma_favorite_control:
      show_on_artwork: true
      favorite_button_size: medium
      favorite_button_offset: 24px 14px
```

