### PR TITLE
feat: add linked volume panel for large multi card PR3

### DIFF
--- a/docs/PR_02_MA_ARTWORK_FAVORITE.md
+++ b/docs/PR_02_MA_ARTWORK_FAVORITE.md
@@ -39,10 +39,15 @@ This PR turns that into a real artwork control while staying inside the boundari
 Supported fields in this PR:
 
 - `show_on_artwork`
+  - enables the artwork overlay button
 - `favorite_button_size`
+  - `small | medium | large`
 - `favorite_button_offset`
+  - one CSS offset value or two values as `x y`
 - `active_color`
+  - icon color when the current item is favorited
 - `inactive_color`
+  - icon color when the current item is not favorited
 
 Example:
 
@@ -83,6 +88,31 @@ That means:
 - multi card editor: per-player under `Music Assistant Integration (optional)`
 
 The artwork-specific controls only appear where there is actually a large artwork surface to place them on.
+
+In practice:
+
+- regular card: available when the card uses popup artwork
+- massive card: available directly
+- multi card: available for large cards
+
+The controls were kept in the MA section on purpose because this is not generic footer/UI customization. It depends on:
+
+- `ma_entity_id`
+- `ma_favorite_button_entity_id`
+- MA queue behavior
+
+### New runtime pieces
+
+This PR adds a dedicated runtime path for the artwork control:
+
+- `MaFavoriteButton`
+- `useMaFavoriteControl`
+
+Why:
+
+- keep the favorite logic isolated from the rest of the artwork/player rendering
+- keep MA-specific edge cases in one place
+- avoid leaking this behavior into unrelated generic button code
 
 ## How the two-way favorite behavior works
 
@@ -133,6 +163,19 @@ and then keeps a very small local override layer so that:
 - the visual state settles back to the real queue state once MA/HA reports it
 
 This ended up being the most reliable compromise without introducing a large custom state machine.
+
+The final behavior is intentionally modest:
+
+- local click sets a short-lived rendered override
+- Home Assistant `call_service` events for favorite/unfavorite also update that rendered override
+- the queue-reported state remains the long-term source of truth
+- a lightweight background refresh remains enabled so multiple open dashboards can converge even when they are otherwise idle
+
+This was the simplest model that still behaved well in testing across:
+
+- local clicks
+- two browser windows
+- Developer Tools manual service calls
 
 ## Important limitation: provider items vs library items
 
@@ -192,6 +235,28 @@ For provider items:
 
 This avoids broken backend errors in the UI and matches the current MA behavior more honestly.
 
+## User-facing behavior summary
+
+### When the current item is a library track
+
+- the star reflects current favorite state
+- clicking it favorites or unfavorites immediately
+- the state should sync quickly across open dashboards
+
+### When the current item is a provider-backed track
+
+- the star can still be used to favorite the track
+- the card warns that the favorite may take time to appear
+- unfavorite is intentionally blocked until MA exposes the track as a library item
+
+### When MA favorite config is missing
+
+If any of the required MA pieces are missing:
+
+- no artwork favorite button is shown
+
+That means the feature remains fully opt-in.
+
 ## Related MA discussion / docs
 
 Useful references for this behavior:
@@ -237,6 +302,15 @@ media_players:
       favorite_button_size: medium
       favorite_button_offset: 24px 14px
 ```
+
+## Screenshots
+
+Suggested screenshots to include in the PR:
+
+- editor screenshot showing the Music Assistant configuration section and artwork favorite controls
+- runtime screenshot showing the favorite button on artwork
+
+Those two images should make the PR much easier to scan quickly.
 
 ## Compatibility
 

--- a/docs/PR_02_MA_ARTWORK_FAVORITE.md
+++ b/docs/PR_02_MA_ARTWORK_FAVORITE.md
@@ -1,0 +1,300 @@
+# PR 2: Music Assistant Artwork Favorite
+
+This document summarizes the second review-sized PR branch:
+
+- branch: `pr/02-ma-artwork-favorite`
+- base: `pr/01-view-and-footer-options`
+
+## Goal
+
+Keep this PR focused on one coherent Music Assistant feature:
+
+- add a configurable MA favorite control on the large player artwork
+- make that control work in both directions when MA exposes enough queue/library information
+- keep the editor/config shape small and MA-specific
+
+This PR intentionally does **not** include:
+
+- favorite controls in the large volume row
+- grouped volume work
+- MA Search / Library redesign
+- extra generic UI customization work
+
+## Why
+
+The card already supported `ma_favorite_button_entity_id`, but that was only a one-way action hidden behind extra actions.
+
+That left three gaps:
+
+- no visible favorite state on the main player surface
+- no clear way to remove a favorite from the same surface
+- no editor support for configuring the artwork placement/appearance
+
+This PR turns that into a real artwork control while staying inside the boundaries that Music Assistant and the Home Assistant integration currently expose.
+
+## What changed
+
+### New config block: `ma_favorite_control`
+
+Supported fields in this PR:
+
+- `show_on_artwork`
+- `favorite_button_size`
+- `favorite_button_offset`
+- `active_color`
+- `inactive_color`
+
+Example:
+
+```yaml
+ma_favorite_control:
+  show_on_artwork: true
+  favorite_button_size: medium
+  favorite_button_offset: 14px
+  active_color: "#f2c94c"
+  inactive_color: "#111111"
+```
+
+Offset behavior:
+
+- one value: applies to both axes
+- two values: `x y`
+- `x` is distance from the right edge
+- `y` is distance from the top edge
+
+Examples:
+
+```yaml
+favorite_button_offset: 14px
+```
+
+```yaml
+favorite_button_offset: 24px 14px
+```
+
+### Editor support
+
+The favorite control is configured inside the existing Music Assistant section, not under generic UI options.
+
+That means:
+
+- single card editor: under `Music Assistant Integration (optional)`
+- massive card editor: under `Music Assistant Integration (optional)`
+- multi card editor: per-player under `Music Assistant Integration (optional)`
+
+The artwork-specific controls only appear where there is actually a large artwork surface to place them on.
+
+## How the two-way favorite behavior works
+
+The working implementation ended up being:
+
+- read favorite state from `music_assistant.get_queue`
+- add favorite by pressing the HA-created MA favorite button entity
+- remove favorite via `mass_queue.unfavorite_current_item`
+
+In practice that means:
+
+### Add favorite
+
+The Home Assistant Music Assistant integration creates a dedicated button entity for "favorite current song".
+
+This PR uses:
+
+- `button.press`
+- target: `ma_favorite_button_entity_id`
+
+Reference:
+
+- Home Assistant Music Assistant integration: `Favorite current song button`
+  - https://www.home-assistant.io/integrations/music_assistant/
+
+### Remove favorite
+
+For removal, this PR uses the MA queue action:
+
+```yaml
+action: mass_queue.unfavorite_current_item
+data:
+  entity: media_player.my_ma_player
+```
+
+This is what makes the control genuinely two-way for tracks that Music Assistant is exposing as library-backed queue items.
+
+### State / refresh behavior
+
+The card reads the current favorite state from:
+
+- `music_assistant.get_queue`
+
+and then keeps a very small local override layer so that:
+
+- clicking the button responds immediately
+- Home Assistant Developer Tools actions show up immediately on open dashboards
+- the visual state settles back to the real queue state once MA/HA reports it
+
+This ended up being the most reliable compromise without introducing a large custom state machine.
+
+## Important limitation: provider items vs library items
+
+This PR needs to be explicit about a current Music Assistant limitation.
+
+Music Assistant favorites are library-backed.
+
+That means there is an important difference between:
+
+- `library://track/...`
+- provider URIs such as `spotify--...://track/...`
+
+### Library items
+
+If the current queue item is already a library item:
+
+- favorite works
+- unfavorite works
+- the control behaves like a real toggle
+
+### Non-library/provider items
+
+If the current queue item is still a provider item:
+
+- favoriting is allowed
+- unfavoriting is **not** allowed yet from this control
+
+Why:
+
+- Music Assistant favorites are a subset of the library
+- favoriting a non-library item first adds it to the MA library
+- that can require metadata work before the track becomes a stable library-backed item
+
+This is why some tracks may initially appear with provider URIs like:
+
+```text
+spotify--...://track/...
+```
+
+and only later show up as:
+
+```text
+library://track/...
+```
+
+Once the current item is library-backed, unfavorite becomes available.
+
+### User-facing behavior in this PR
+
+For provider items:
+
+- clicking the control when not favorited still sends the favorite action
+- the card shows:
+  - `For non-library items, favoriting may take a few minutes to appear.`
+- if the user tries to unfavorite a non-library item, the card shows:
+  - `Unfavorite is only available for library tracks.`
+
+This avoids broken backend errors in the UI and matches the current MA behavior more honestly.
+
+## Related MA discussion / docs
+
+Useful references for this behavior:
+
+- Home Assistant Music Assistant integration
+  - https://www.home-assistant.io/integrations/music_assistant/
+- Music Assistant discussion about favorite services / current-item favorite workflows
+  - https://github.com/orgs/music-assistant/discussions/1984
+- Music Assistant Spotify provider docs
+  - https://www.music-assistant.io/music-providers/spotify/
+
+The relevant MA behavior here is that favoriting a provider-backed item effectively turns into "add to library + favorite", which is why non-library items may not reflect instantly.
+
+## Example
+
+```yaml
+type: custom:mediocre-massive-media-player-card
+entity_id: media_player.ma_basement_sonos
+mode: card
+ma_entity_id: media_player.ma_basement_sonos
+ma_favorite_button_entity_id: button.ma_basement_favorite_current_song
+ma_favorite_control:
+  show_on_artwork: true
+  favorite_button_size: medium
+  favorite_button_offset: 14px
+  active_color: "#f2c94c"
+  inactive_color: "#111111"
+```
+
+For multi card usage:
+
+```yaml
+type: custom:mediocre-multi-media-player-card
+entity_id: media_player.ma_basement_sonos
+size: large
+mode: card
+media_players:
+  - entity_id: media_player.ma_basement_sonos
+    ma_entity_id: media_player.ma_basement_sonos
+    ma_favorite_button_entity_id: button.ma_basement_favorite_current_song
+    ma_favorite_control:
+      show_on_artwork: true
+      favorite_button_size: medium
+      favorite_button_offset: 24px 14px
+```
+
+## Compatibility
+
+This PR is additive and intentionally narrow.
+
+- existing cards do not need YAML changes
+- existing `ma_favorite_button_entity_id` behavior still works
+- if `ma_favorite_control` is omitted, nothing new is shown
+- the config is kept MA-specific rather than adding another generic UI customization layer
+
+## Scope
+
+Included here:
+
+- artwork favorite button
+- MA-specific config/editor support
+- two-way behavior for library-backed items
+- graceful provider-item handling
+
+Still out of scope:
+
+- favorite button on the volume row
+- grouped volume panel
+- larger MA Search / Library changes
+
+## Files changed
+
+Runtime/UI:
+
+- [AlbumArt.tsx](/g:/Documents/Code%202025/repos/mediocre-hass-media-player-cards/src/components/AlbumArt/AlbumArt.tsx)
+- [MassivePlaybackController.tsx](/g:/Documents/Code%202025/repos/mediocre-hass-media-player-cards/src/components/MassivePlaybackController/MassivePlaybackController.tsx)
+- [MaFavoriteButton.tsx](/g:/Documents/Code%202025/repos/mediocre-hass-media-player-cards/src/components/MaFavoriteButton/MaFavoriteButton.tsx)
+- [useMaFavoriteControl.ts](/g:/Documents/Code%202025/repos/mediocre-hass-media-player-cards/src/hooks/useMaFavoriteControl.ts)
+
+Editor/config plumbing:
+
+- [FieldGroupMaEntities.tsx](/g:/Documents/Code%202025/repos/mediocre-hass-media-player-cards/src/components/Form/components/FieldGroupMaEntities.tsx)
+- [MediocreMassiveMediaPlayerCardEditor.tsx](/g:/Documents/Code%202025/repos/mediocre-hass-media-player-cards/src/components/MediocreMassiveMediaPlayerCard/MediocreMassiveMediaPlayerCardEditor.tsx)
+- [MediocreMediaPlayerCardEditor.tsx](/g:/Documents/Code%202025/repos/mediocre-hass-media-player-cards/src/components/MediocreMediaPlayerCard/MediocreMediaPlayerCardEditor.tsx)
+- [MediocreMultiMediaPlayerCardEditor.tsx](/g:/Documents/Code%202025/repos/mediocre-hass-media-player-cards/src/components/MediocreMultiMediaPlayerCard/MediocreMultiMediaPlayerCardEditor.tsx)
+- [config.ts](/g:/Documents/Code%202025/repos/mediocre-hass-media-player-cards/src/types/config.ts)
+- [cardConfigUtils.ts](/g:/Documents/Code%202025/repos/mediocre-hass-media-player-cards/src/utils/cardConfigUtils.ts)
+- [getMediocreLegacyConfigToMultiConfig.ts](/g:/Documents/Code%202025/repos/mediocre-hass-media-player-cards/src/utils/getMediocreLegacyConfigToMultiConfig.ts)
+- [getMediocreMassiveLegacyConfigToMultiConfig.ts](/g:/Documents/Code%202025/repos/mediocre-hass-media-player-cards/src/utils/getMediocreMassiveLegacyConfigToMultiConfig.ts)
+- [getMultiConfigToMediocreMassiveConfig.ts](/g:/Documents/Code%202025/repos/mediocre-hass-media-player-cards/src/utils/getMultiConfigToMediocreMassiveConfig.ts)
+- [index.ts](/g:/Documents/Code%202025/repos/mediocre-hass-media-player-cards/src/components/index.ts)
+- [index.ts](/g:/Documents/Code%202025/repos/mediocre-hass-media-player-cards/src/hooks/index.ts)
+
+Tests:
+
+- [maFavoriteArtwork.config.test.ts](/g:/Documents/Code%202025/repos/mediocre-hass-media-player-cards/src/utils/maFavoriteArtwork.config.test.ts)
+
+## Validation
+
+Validated on this branch with:
+
+- `yarn tsc --noEmit`
+- `yarn test`
+- `yarn build`
+
+I also generated a `.gz` build artifact locally for Home Assistant testing.

--- a/docs/PR_03_LINKED_VOLUME_PANEL.md
+++ b/docs/PR_03_LINKED_VOLUME_PANEL.md
@@ -1,0 +1,250 @@
+## Summary
+
+This PR adds a configurable `Linked Volume Panel` to the large multi-player card.
+
+It is aimed at setups where one selected player is logically tied to one or more
+other volume-controlled endpoints, for example:
+
+- a Sonos player that also feeds an AVR
+- a player plus one or more zones with their own volume controls
+- a player that sometimes participates in a runtime speaker group
+
+The feature is intentionally config-first.
+
+It introduces:
+
+- a per-player `linked_volume_panel` config block
+- a new `Volume Panel` view in the large multi-player card
+- a per-player launch setting for opening that panel from the trailing volume-bar button
+- optional inclusion of grouped players at runtime
+- a UI customization override for the trailing volume button icon
+
+This PR is intentionally limited to the large multi-player card. It does not add
+single-card or massive-card support.
+
+## Why
+
+The previous idea for this area was too split across unrelated settings.
+
+In practice, the linked/grouped volume feature needs to answer three separate
+questions together:
+
+- which endpoints should appear in the panel
+- whether grouped players should also be included at runtime
+- how the user opens the panel
+
+Putting launch behavior in generic `options` while the actual linked entities
+lived under the player config made the model harder to understand.
+
+This PR moves the activation point into the per-player panel config itself, so
+the feature can be read as one coherent block.
+
+## Config
+
+### Per-player: `linked_volume_panel`
+
+Supported fields:
+
+- `launch_from`
+  - `disabled | trailing_volume_bar_button`
+- `include_grouped_players`
+  - `true | false`
+- `entities`
+  - ordered list of linked media-player rows
+
+Each entity row supports:
+
+- `entity_id`
+- `name`
+- `icon`
+- `show_power`
+
+Important rule:
+
+- if you want the selected player itself to appear in the panel, add it
+  explicitly to `entities`
+
+That rule keeps the feature predictable. The panel shows explicitly configured
+rows first, and only then optionally appends grouped players.
+
+### UI customization
+
+The launch icon override stays in UI customization:
+
+```yaml
+options:
+  ui:
+    volume_bar:
+      trailing_volume_button_icon: mdi:volume-source
+```
+
+This is only an icon override. The feature activation itself lives in
+`linked_volume_panel`.
+
+## Example
+
+### Explicit linked endpoints only
+
+```yaml
+type: custom:mediocre-multi-media-player-card
+entity_id: media_player.ma_basement_sonos
+size: large
+mode: card
+media_players:
+  - entity_id: media_player.ma_basement_sonos
+    linked_volume_panel:
+      launch_from: trailing_volume_bar_button
+      entities:
+        - entity_id: media_player.ma_basement_sonos
+          name: MA Basement Sonos
+        - entity_id: media_player.family_pioneer
+          name: Family Pioneer
+          show_power: true
+```
+
+### Explicit endpoints plus grouped players
+
+```yaml
+type: custom:mediocre-multi-media-player-card
+entity_id: media_player.ma_basement_sonos
+size: large
+mode: card
+options:
+  ui:
+    volume_bar:
+      trailing_volume_button_icon: mdi:volume-source
+media_players:
+  - entity_id: media_player.ma_basement_sonos
+    linked_volume_panel:
+      launch_from: trailing_volume_bar_button
+      include_grouped_players: true
+      entities:
+        - entity_id: media_player.ma_basement_sonos
+          name: MA Basement Sonos
+        - entity_id: media_player.family_pioneer
+          name: Family Pioneer
+          show_power: true
+  - entity_id: media_player.ma_dining_sonos
+    linked_volume_panel:
+      entities:
+        - entity_id: media_player.ma_dining_sonos
+          name: MA Dining Sonos
+```
+
+In that case:
+
+- the selected player's configured rows appear first
+- if the selected player is grouped with other configured players, each grouped
+  player gets its own section
+- grouped-player sections include that player's own row by default, plus any
+  linked rows explicitly configured for that grouped player
+
+## Editor support
+
+This PR adds editor support for the large multi-player card.
+
+Per player:
+
+- `Linked Volume Panel (optional)`
+  - `Launch Panel from`
+  - `Include Grouped Players`
+  - `Volume Panel Entities`
+
+UI customization:
+
+- `UI Customization (optional)`
+  - `Volume Bar`
+    - `Trailing volume button icon`
+
+This matches the runtime model much more closely than the earlier split
+between panel setup and generic advanced options.
+
+## Runtime behavior
+
+### Launch behavior
+
+The trailing volume-bar button behaves per selected player:
+
+- if `launch_from` is `trailing_volume_bar_button` and the selected player has
+  a usable linked volume panel, the trailing button opens the panel
+- otherwise the trailing button remains the normal power button
+
+### Panel structure
+
+The panel view is rendered as sections by player.
+
+For example:
+
+- section: `MA Basement Sonos`
+  - `MA Basement Sonos`
+  - `Family Pioneer`
+- section: `MA Dining Sonos`
+  - `MA Dining Sonos`
+
+This makes grouped/runtime additions much easier to read than a flat list.
+
+### Row behavior
+
+Each row is a media-player row:
+
+- volume acts on that row's `entity_id`
+- mute acts on that row's `entity_id`
+- optional power acts on that row's `entity_id`
+
+There is no separate `power_entity_id` in this design.
+
+### Close behavior
+
+The `Volume Panel` header includes a close icon that returns to the main player
+view.
+
+## Scope
+
+Included here:
+
+- large multi-card linked volume panel
+- per-player launch activation
+- grouped-player inclusion
+- ordered linked entity rows
+- optional per-row power button
+- trailing volume button icon override
+- editor support
+
+Intentionally not included:
+
+- single-card support
+- massive-card support
+- custom trailing button launch targets
+- favorite/custom trailing modes
+- legacy compatibility layers for older grouped-volume config ideas
+
+## Compatibility
+
+This PR is additive.
+
+- existing configs do not need changes
+- if `linked_volume_panel` is omitted, nothing new appears
+- if `launch_from` is omitted or `disabled`, the trailing volume button remains
+  the normal power button
+
+## Validation
+
+Validated locally with:
+
+- `yarn tsc --noEmit`
+- `yarn test`
+- `yarn build`
+
+Artifacts generated:
+
+- `dist/mediocre-hass-media-player-cards.js`
+- `dist/mediocre-hass-media-player-cards.js.gz`
+
+## Suggested screenshots
+
+- editor screenshot showing `Linked Volume Panel (optional)`
+- runtime screenshot showing `Volume Panel` sectioned by player
+
+## Note on stacking
+
+This PR is intended to be reviewed on top of `pr/02-ma-artwork-favorite`.

--- a/src/components/AlbumArt/AlbumArt.tsx
+++ b/src/components/AlbumArt/AlbumArt.tsx
@@ -1,4 +1,4 @@
-import { Icon, IconSize, usePlayer } from "@components";
+import { Icon, IconSize, MaFavoriteButton, usePlayer } from "@components";
 import { fadeIn, theme } from "@constants";
 import { css } from "@emotion/react";
 import { getDeviceIcon, getSourceIcon } from "@utils";
@@ -11,6 +11,7 @@ export type AlbumArtProps = {
   borderRadius?: number;
   iconSize: IconSize;
   renderLongPressIndicator?: () => JSX.Element | null;
+  showMaFavoriteButton?: boolean;
 } & ButtonHTMLAttributes<HTMLButtonElement>;
 
 const styles = {
@@ -69,6 +70,7 @@ export const AlbumArt = ({
   borderRadius = 4,
   iconSize,
   renderLongPressIndicator,
+  showMaFavoriteButton = false,
   ...buttonProps
 }: AlbumArtProps) => {
   const player = usePlayer();
@@ -194,6 +196,7 @@ export const AlbumArt = ({
           </div>
         )}
       </div>
+      {showMaFavoriteButton && <MaFavoriteButton />}
       {renderLongPressIndicator && renderLongPressIndicator()}
     </button>
   );

--- a/src/components/Form/components/FieldGroupMaEntities.tsx
+++ b/src/components/Form/components/FieldGroupMaEntities.tsx
@@ -1,9 +1,19 @@
 import { withFieldGroup } from "../hooks/useAppForm";
 import { Fragment } from "preact/jsx-runtime";
+import { css } from "@emotion/react";
+import { Label, SubForm } from "@components";
+import { InputGroup } from "@components/FormElements";
 
 type MaEntitiesFields = {
   ma_entity_id?: string | null;
   ma_favorite_button_entity_id?: string | null;
+  ma_favorite_control?: {
+    show_on_artwork?: boolean | null;
+    favorite_button_size?: "small" | "medium" | "large";
+    favorite_button_offset?: string | null;
+    active_color?: string | null;
+    inactive_color?: string | null;
+  } | null;
 };
 
 const defaultValues: MaEntitiesFields = {
@@ -11,10 +21,74 @@ const defaultValues: MaEntitiesFields = {
   ma_favorite_button_entity_id: null,
 };
 
+const styles = {
+  helperText: css({
+    display: "block",
+    marginBottom: "12px",
+    opacity: 0.8,
+  }),
+  sectionIntro: css({
+    display: "block",
+    marginBottom: "12px",
+    opacity: 0.75,
+    lineHeight: 1.4,
+  }),
+  sizeRow: css({
+    maxWidth: "360px",
+    marginBottom: "16px",
+  }),
+  offsetRow: css({
+    marginBottom: "16px",
+  }),
+  toggleField: css({
+    marginBottom: "12px",
+  }),
+  fieldGrid: css({
+    display: "grid",
+    gridTemplateColumns: "repeat(2, minmax(0, 1fr))",
+    gap: "12px",
+    alignItems: "start",
+    "@media (max-width: 720px)": {
+      gridTemplateColumns: "1fr",
+    },
+  }),
+  fieldLabel: css({
+    display: "block",
+    marginBottom: "8px",
+    fontWeight: 500,
+  }),
+  select: css({
+    width: "100%",
+    minHeight: "56px",
+    padding: "0 16px",
+    borderRadius: "12px",
+    border: "1px solid rgba(0, 0, 0, 0.18)",
+    backgroundColor: "var(--card-background-color, #fff)",
+    color: "var(--primary-text-color)",
+    font: "inherit",
+    boxSizing: "border-box",
+    outline: "none",
+    ":focus": {
+      borderColor: "var(--primary-color)",
+      boxShadow: "0 0 0 1px var(--primary-color)",
+    },
+  }),
+};
+
 export const FieldGroupMaEntities = withFieldGroup({
   defaultValues,
-  props: {},
-  render: function Render({ group }) {
+  props: {
+    artworkFavoriteHelperText: "" as string | undefined,
+    showArtworkFavoriteControls: true,
+  },
+  render: function Render({
+    artworkFavoriteHelperText,
+    group,
+    showArtworkFavoriteControls,
+  }) {
+    const showArtworkFields =
+      group.state.values.ma_favorite_control?.show_on_artwork === true;
+
     return (
       <Fragment>
         <group.AppField
@@ -35,6 +109,81 @@ export const FieldGroupMaEntities = withFieldGroup({
             />
           )}
         />
+        {artworkFavoriteHelperText ? (
+          <Label css={styles.helperText}>{artworkFavoriteHelperText}</Label>
+        ) : null}
+        {showArtworkFavoriteControls ? (
+          <SubForm
+            title="Favorite Button on Artwork (optional)"
+            initiallyExpanded={showArtworkFields}
+          >
+            <Label css={styles.sectionIntro}>
+              Adds a Music Assistant favorite toggle to the artwork overlay in
+              the large or popup player view.
+            </Label>
+            <group.AppField
+              name="ma_favorite_control.show_on_artwork"
+              children={field => (
+                <div css={styles.toggleField}>
+                  <field.Toggle label="Show favorite button on artwork" />
+                </div>
+              )}
+            />
+            {showArtworkFields ? (
+              <Fragment>
+                <div css={styles.sizeRow}>
+                  <group.Field name="ma_favorite_control.favorite_button_size">
+                    {field => (
+                      <InputGroup>
+                        <Label css={styles.fieldLabel}>Button size</Label>
+                        <select
+                          css={styles.select}
+                          onChange={event =>
+                            field.handleChange(
+                              (event.target as HTMLSelectElement).value as
+                                | "small"
+                                | "medium"
+                                | "large"
+                            )
+                          }
+                          value={field.state.value ?? "small"}
+                        >
+                          <option value="small">Small</option>
+                          <option value="medium">Medium</option>
+                          <option value="large">Large</option>
+                        </select>
+                      </InputGroup>
+                    )}
+                  </group.Field>
+                </div>
+                <div css={styles.offsetRow}>
+                  <group.AppField
+                    name="ma_favorite_control.favorite_button_offset"
+                    children={field => (
+                      <field.Text label="Offset (14px or 24px 14px)" />
+                    )}
+                  />
+                </div>
+                <div css={styles.fieldGrid}>
+                  <group.AppField
+                    name="ma_favorite_control.active_color"
+                    children={field => (
+                      <field.Text label="Active color (default: #f2c94c)" />
+                    )}
+                  />
+                  <group.AppField
+                    name="ma_favorite_control.inactive_color"
+                    children={field => (
+                      <field.Text label="Inactive color (default: #111111)" />
+                    )}
+                  />
+                </div>
+              </Fragment>
+            ) : (
+              <Fragment />
+            )}
+          </SubForm>
+        ) : null}
       </Fragment>
     );
   },

--- a/src/components/Form/components/FieldGroupVolumePanel.tsx
+++ b/src/components/Form/components/FieldGroupVolumePanel.tsx
@@ -1,0 +1,187 @@
+import { LinkedVolumePanel } from "@types";
+import { withFieldGroup } from "../hooks/useAppForm";
+import { Fragment } from "preact/jsx-runtime";
+import { css } from "@emotion/react";
+import { EntityPicker, InputGroup } from "@components/FormElements";
+import { FormGroup, Label, SubForm } from "@components";
+import { useHass } from "@components/HassContext";
+
+type VolumePanelFields = {
+  linked_volume_panel?: LinkedVolumePanel | null;
+};
+
+const defaultValues: VolumePanelFields = {
+  linked_volume_panel: {
+    launch_from: "disabled",
+    include_grouped_players: false,
+    entities: [],
+  },
+};
+
+const styles = {
+  helperText: css({
+    display: "block",
+    marginBottom: "12px",
+    opacity: 0.75,
+    lineHeight: 1.4,
+  }),
+  selectRow: css({
+    maxWidth: "360px",
+    marginBottom: "16px",
+  }),
+  toggleRow: css({
+    marginBottom: "16px",
+  }),
+  select: css({
+    width: "100%",
+    minHeight: "56px",
+    padding: "0 16px",
+    borderRadius: "12px",
+    border: "1px solid rgba(0, 0, 0, 0.18)",
+    backgroundColor: "var(--card-background-color, #fff)",
+    color: "var(--primary-text-color)",
+    font: "inherit",
+    boxSizing: "border-box",
+    outline: "none",
+    ":focus": {
+      borderColor: "var(--primary-color)",
+      boxShadow: "0 0 0 1px var(--primary-color)",
+    },
+  }),
+  fieldLabel: css({
+    display: "block",
+    marginBottom: "8px",
+    fontWeight: 500,
+  }),
+  entitySectionLabel: css({
+    display: "block",
+    margin: "4px 0 12px",
+    fontWeight: 600,
+  }),
+  addEntity: css({
+    marginTop: "12px",
+  }),
+};
+
+export const FieldGroupVolumePanel = withFieldGroup({
+  defaultValues,
+  props: {},
+  render: function Render({ group }) {
+    const hass = useHass();
+
+    return (
+      <Fragment>
+        <Label css={styles.helperText}>
+          Configure which linked volume endpoints should appear for this player
+          in the Volume Panel.
+        </Label>
+        <div css={styles.selectRow}>
+          <group.Field name="linked_volume_panel.launch_from">
+            {field => (
+              <InputGroup>
+                <Label css={styles.fieldLabel}>Launch Panel from</Label>
+                <select
+                  css={styles.select}
+                  onChange={event =>
+                    field.handleChange(
+                      (event.target as HTMLSelectElement).value as
+                        | "disabled"
+                        | "trailing_volume_bar_button"
+                    )
+                  }
+                  value={field.state.value ?? "disabled"}
+                >
+                  <option value="disabled">Disabled</option>
+                  <option value="trailing_volume_bar_button">
+                    Trailing Volume Button
+                  </option>
+                </select>
+              </InputGroup>
+            )}
+          </group.Field>
+        </div>
+        <div css={styles.toggleRow}>
+          <group.AppField
+            name="linked_volume_panel.include_grouped_players"
+            children={field => (
+              <field.Toggle label="Include Grouped Players" />
+            )}
+          />
+        </div>
+        <Label css={styles.entitySectionLabel}>Volume Panel Entities</Label>
+        <group.Field name="linked_volume_panel.entities" mode="array">
+          {entitiesField => (
+            <Fragment>
+              {entitiesField.state.value?.map((entity, index) => (
+                <SubForm
+                  title={entity.name ?? entity.entity_id ?? `Entity ${index + 1}`}
+                  buttons={[
+                    {
+                      icon: "mdi:delete",
+                      onClick: () => entitiesField.removeValue(index),
+                    },
+                    {
+                      icon: "mdi:arrow-up",
+                      onClick: () => entitiesField.moveValue(index, index - 1),
+                    },
+                    {
+                      icon: "mdi:arrow-down",
+                      onClick: () => entitiesField.moveValue(index, index + 1),
+                    },
+                  ]}
+                  key={index}
+                >
+                  <FormGroup>
+                    <group.AppField
+                      name={`linked_volume_panel.entities[${index}].entity_id`}
+                      children={field => (
+                        <field.EntityPicker
+                          label="Media Player Entity ID"
+                          domains={["media_player"]}
+                          required
+                        />
+                      )}
+                    />
+                    <group.AppField
+                      name={`linked_volume_panel.entities[${index}].name`}
+                      children={field => <field.Text label="Name (optional)" />}
+                    />
+                    <group.AppField
+                      name={`linked_volume_panel.entities[${index}].icon`}
+                      children={field => (
+                        <field.Text label="Icon (optional)" isIconInput />
+                      )}
+                    />
+                    <group.AppField
+                      name={`linked_volume_panel.entities[${index}].show_power`}
+                      children={field => (
+                        <field.Toggle label="Show power button for this media player" />
+                      )}
+                    />
+                  </FormGroup>
+                </SubForm>
+              ))}
+              <div css={styles.addEntity}>
+                <EntityPicker
+                  hass={hass}
+                  value=""
+                  onChange={value => {
+                    if (!value) return;
+                    entitiesField.pushValue({
+                      entity_id: value,
+                      name:
+                        hass.states[value]?.attributes?.friendly_name ??
+                        undefined,
+                    });
+                  }}
+                  label="Add volume panel entity"
+                  domains={["media_player"]}
+                />
+              </div>
+            </Fragment>
+          )}
+        </group.Field>
+      </Fragment>
+    );
+  },
+});

--- a/src/components/MaFavoriteButton/MaFavoriteButton.tsx
+++ b/src/components/MaFavoriteButton/MaFavoriteButton.tsx
@@ -1,0 +1,211 @@
+import { css } from "@emotion/react";
+import { Spinner } from "@components/Spinner";
+import { JSX } from "preact";
+import { useMaFavoriteControl } from "@hooks";
+
+const NON_LIBRARY_FAVORITE_MESSAGE =
+  "For non-library items, favoriting may take a few minutes to appear.";
+const NON_LIBRARY_UNFAVORITE_MESSAGE =
+  "Unfavorite is only available for library tracks.";
+
+const styles = {
+  container: css({
+    position: "absolute",
+    zIndex: 2,
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "flex-end",
+    gap: 8,
+    pointerEvents: "none",
+  }),
+  root: css({
+    pointerEvents: "auto",
+    borderRadius: "999px",
+    boxShadow: "0 2px 10px rgba(0, 0, 0, 0.2)",
+    backdropFilter: "blur(6px)",
+    color: "var(--mmpc-ma-favorite-color)",
+    "@media (hover: hover)": {
+      "&:hover": {
+        backgroundColor: "var(--mmpc-ma-favorite-hover-background)",
+      },
+    },
+    transition: "opacity 120ms ease, transform 120ms ease",
+  }),
+  active: css({
+    backgroundColor: "rgba(20, 20, 20, 0.66)",
+    border: "1px solid rgba(255, 255, 255, 0.16)",
+  }),
+  inactive: css({
+    backgroundColor: "rgba(235, 235, 235, 0.5)",
+    border: "1px solid rgba(255, 255, 255, 0.45)",
+  }),
+  button: css({
+    position: "relative",
+    appearance: "none",
+    background: "none",
+    border: "none",
+    cursor: "pointer",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: "999px",
+    padding: 4,
+    minWidth: "var(--mmpc-ma-favorite-button-size)",
+    minHeight: "var(--mmpc-ma-favorite-button-size)",
+    color: "inherit",
+    touchAction: "manipulation",
+    "-webkit-tap-highlight-color": "transparent",
+    "> ha-icon": {
+      "--mdc-icon-size": "var(--mmpc-ma-favorite-button-size)",
+      width: "var(--mmpc-ma-favorite-button-size)",
+      height: "var(--mmpc-ma-favorite-button-size)",
+      display: "flex",
+      pointerEvents: "none",
+    },
+  }),
+  busyIcon: css({
+    opacity: 0.35,
+  }),
+  spinnerOverlay: css({
+    position: "absolute",
+    inset: 0,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    pointerEvents: "none",
+  }),
+};
+
+const fireHassNotification = (message: string) => {
+  document.body?.dispatchEvent(
+    new CustomEvent("hass-notification", {
+      bubbles: true,
+      composed: true,
+      detail: { message },
+    })
+  );
+};
+
+const getOffsetPosition = (offset: string) => {
+  const parts = offset
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean);
+  const [xOffset, yOffset] =
+    parts.length >= 2
+      ? [parts[0], parts[1]]
+      : [parts[0] || "14px", parts[0] || "14px"];
+
+  return {
+    right: xOffset,
+    top: yOffset,
+  };
+};
+
+const getButtonSize = (size: "small" | "medium" | "large") => {
+  switch (size) {
+    case "medium":
+      return 32;
+    case "large":
+      return 40;
+    case "small":
+    default:
+      return 24;
+  }
+};
+
+export const MaFavoriteButton = () => {
+  const {
+    activeColor,
+    enabled,
+    favoriteButtonOffset,
+    favoriteButtonSize,
+    inactiveColor,
+    isLibraryItem,
+    isFavorite,
+    isLoading,
+    toggleFavorite,
+    unsupportedMessage,
+  } = useMaFavoriteControl();
+
+  if (!enabled) return null;
+
+  const handleOnClick: JSX.MouseEventHandler<HTMLDivElement> = event => {
+    event.preventDefault();
+    event.stopPropagation();
+    if (isLoading) return;
+    if (!isLibraryItem && isFavorite) {
+      fireHassNotification(NON_LIBRARY_UNFAVORITE_MESSAGE);
+      return;
+    }
+    if (!isLibraryItem) {
+      fireHassNotification(NON_LIBRARY_FAVORITE_MESSAGE);
+    }
+    void toggleFavorite();
+  };
+
+  const handleOnKeyDown: JSX.KeyboardEventHandler<HTMLDivElement> = event => {
+    if (event.key !== "Enter" && event.key !== " ") return;
+    event.preventDefault();
+    event.stopPropagation();
+    if (isLoading) return;
+    if (!isLibraryItem && isFavorite) {
+      fireHassNotification(NON_LIBRARY_UNFAVORITE_MESSAGE);
+      return;
+    }
+    if (!isLibraryItem) {
+      fireHassNotification(NON_LIBRARY_FAVORITE_MESSAGE);
+    }
+    void toggleFavorite();
+  };
+
+  return (
+    <div
+      css={styles.container}
+      style={{
+        ...getOffsetPosition(favoriteButtonOffset),
+      }}
+    >
+      <div
+        aria-label={isFavorite ? "Remove favorite" : "Add favorite"}
+        aria-busy={isLoading}
+        css={[styles.root, isFavorite ? styles.active : styles.inactive]}
+        onClick={handleOnClick}
+        onKeyDown={handleOnKeyDown}
+        role="button"
+        style={{
+          "--mmpc-ma-favorite-button-size": `${getButtonSize(
+            favoriteButtonSize
+          )}px`,
+          "--mmpc-ma-favorite-color": isFavorite ? activeColor : inactiveColor,
+          "--mmpc-ma-favorite-hover-background": isFavorite
+            ? "rgba(20, 20, 20, 0.8)"
+            : "rgba(235, 235, 235, 0.62)",
+          "--icon-primary-color": isFavorite ? activeColor : inactiveColor,
+          color: isFavorite ? activeColor : inactiveColor,
+          cursor:
+            !isLibraryItem && isFavorite
+              ? "not-allowed"
+              : isLoading
+                ? "progress"
+                : "pointer",
+          opacity: isLoading ? 0.72 : 1,
+        }}
+        tabIndex={0}
+        title={unsupportedMessage}
+      >
+        <div css={styles.button}>
+          <ha-icon
+            css={isLoading ? styles.busyIcon : undefined}
+            icon={isFavorite ? "mdi:star" : "mdi:star-outline"}
+          />
+          {isLoading ? (
+            <div css={styles.spinnerOverlay}>
+              <Spinner size={favoriteButtonSize} />
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/MaFavoriteButton/index.ts
+++ b/src/components/MaFavoriteButton/index.ts
@@ -1,0 +1,1 @@
+export * from "./MaFavoriteButton";

--- a/src/components/MassivePlaybackController/MassivePlaybackController.tsx
+++ b/src/components/MassivePlaybackController/MassivePlaybackController.tsx
@@ -30,7 +30,12 @@ export const MassivePlaybackController = ({
 }: MassivePlaybackControllerProps) => {
   return (
     <div css={styles.root} className={className}>
-      <AlbumArt iconSize="x-large" borderRadius={8} {...artworkButtonProps} />
+      <AlbumArt
+        iconSize="x-large"
+        borderRadius={8}
+        showMaFavoriteButton={true}
+        {...artworkButtonProps}
+      />
       <Title />
       <Track />
       <PlaybackControls />

--- a/src/components/MediocreLargeMultiMediaPlayerCard/MediocreLargeMultiMediaPlayerCard.tsx
+++ b/src/components/MediocreLargeMultiMediaPlayerCard/MediocreLargeMultiMediaPlayerCard.tsx
@@ -13,6 +13,7 @@ import {
   MiniPlayer,
   SearchView,
   SpeakerGrouping,
+  VolumePanelView,
 } from "./components";
 import { useMeasure } from "@uidotdev/usehooks";
 import { css } from "@emotion/react";
@@ -28,6 +29,7 @@ export type NavigationRoute =
   | "media-browser"
   | "massive"
   | "speaker-grouping"
+  | "volume-panel"
   | "custom-buttons"
   | "queue"
   | "speaker-overview";
@@ -223,6 +225,9 @@ export const MediocreLargeMultiMediaPlayerCard = ({
           <MediaBrowserView height={contentHeight} />
         )}
         {navigationRoute === "speaker-grouping" && <SpeakerGrouping />}
+        {navigationRoute === "volume-panel" && (
+          <VolumePanelView onClose={() => setNavigationRoute("massive")} />
+        )}
         {navigationRoute === "queue" && contentHeight && (
           <QueueView height={contentHeight} />
         )}

--- a/src/components/MediocreLargeMultiMediaPlayerCard/components/FooterActions.tsx
+++ b/src/components/MediocreLargeMultiMediaPlayerCard/components/FooterActions.tsx
@@ -67,7 +67,8 @@ export const FooterActions = memo<FooterActionsProps>(
     const hasSearch = getHasSearch(search, ma_entity_id);
     const hasMediaBrowser = getHasMediaBrowser(media_browser);
     const hasQueue = useCanDisplayQueue({ ma_entity_id, lms_entity_id });
-    const footerIcons = config.options?.ui?.footer_icons;
+    const footerIcons =
+      config.size === "large" ? config.options?.ui?.footer_icons : undefined;
     const getFooterIcon = (key: keyof typeof defaultFooterIcons) =>
       footerIcons?.[key]?.trim() || defaultFooterIcons[key];
 

--- a/src/components/MediocreLargeMultiMediaPlayerCard/components/FooterActions.tsx
+++ b/src/components/MediocreLargeMultiMediaPlayerCard/components/FooterActions.tsx
@@ -35,6 +35,12 @@ const styles = {
   }),
 };
 
+const defaultFooterIcons = {
+  player: "mdi:home",
+  search: "mdi:magnify",
+  media_browser: "mdi:folder-music",
+} as const;
+
 export type FooterActionsProps = {
   setNavigationRoute: (route: NavigationRoute) => void;
   navigationRoute: NavigationRoute;
@@ -61,6 +67,9 @@ export const FooterActions = memo<FooterActionsProps>(
     const hasSearch = getHasSearch(search, ma_entity_id);
     const hasMediaBrowser = getHasMediaBrowser(media_browser);
     const hasQueue = useCanDisplayQueue({ ma_entity_id, lms_entity_id });
+    const footerIcons = config.options?.ui?.footer_icons;
+    const getFooterIcon = (key: keyof typeof defaultFooterIcons) =>
+      footerIcons?.[key]?.trim() || defaultFooterIcons[key];
 
     if (config.size && config.size !== "large") return null;
 
@@ -71,7 +80,7 @@ export const FooterActions = memo<FooterActionsProps>(
         {!desktopMode && (
           <IconButton
             size="small"
-            icon={"mdi:home"}
+            icon={getFooterIcon("player")}
             onClick={() => setNavigationRoute("massive")}
             selected={navigationRoute === "massive"}
           />
@@ -79,7 +88,7 @@ export const FooterActions = memo<FooterActionsProps>(
         {hasSearch && (
           <IconButton
             size="small"
-            icon={"mdi:magnify"}
+            icon={getFooterIcon("search")}
             onClick={() => setNavigationRoute("search")}
             selected={navigationRoute === "search"}
           />
@@ -87,7 +96,7 @@ export const FooterActions = memo<FooterActionsProps>(
         {hasMediaBrowser && (
           <IconButton
             size="small"
-            icon={"mdi:folder-music"}
+            icon={getFooterIcon("media_browser")}
             onClick={() => setNavigationRoute("media-browser")}
             selected={navigationRoute === "media-browser"}
           />

--- a/src/components/MediocreLargeMultiMediaPlayerCard/components/MassiveView.tsx
+++ b/src/components/MediocreLargeMultiMediaPlayerCard/components/MassiveView.tsx
@@ -10,7 +10,12 @@ import {
   usePlayer,
   VolumeSlider,
 } from "@components";
-import { getDeviceIcon, getHass, getVolumeIcon } from "@utils";
+import {
+  getCanOpenLinkedVolumePanel,
+  getDeviceIcon,
+  getHass,
+  getVolumeIcon,
+} from "@utils";
 import { useActionProps } from "@hooks";
 import { theme } from "@constants/theme";
 import { memo } from "preact/compat";
@@ -108,6 +113,11 @@ export const MassiveViewView = memo<MassiveViewViewProps>(
     const groupMembers =
       hass.states[mediaPlayer.speaker_group_entity_id ?? mediaPlayer.entity_id]
         ?.attributes?.group_members;
+    const canOpenLinkedVolumePanel = getCanOpenLinkedVolumePanel(
+      mediaPlayer,
+      config.media_players,
+      hass.states
+    );
     const mdiIcon = getDeviceIcon({ icon, deviceClass });
 
     const moreInfoButtonProps = useActionProps({
@@ -179,10 +189,46 @@ export const MassiveViewView = memo<MassiveViewViewProps>(
                 config.options?.use_volume_up_down_for_step_buttons ?? false
               }
             />
-            <IconButton size="small" onClick={togglePower} icon={"mdi:power"} />
+            <VolumeTrailingButton
+              launchFrom={
+                mediaPlayer.linked_volume_panel?.launch_from ?? "disabled"
+              }
+              canOpenLinkedVolumePanel={canOpenLinkedVolumePanel}
+              icon={
+                config.options?.ui?.volume_bar?.trailing_volume_button_icon?.trim() ||
+                "mdi:volume-source"
+              }
+              onOpenLinkedVolumePanel={() => setNavigationRoute("volume-panel")}
+              onPower={togglePower}
+            />
           </div>
         </MassivePlaybackController>
       </div>
     );
   }
 );
+
+const VolumeTrailingButton = ({
+  launchFrom,
+  canOpenLinkedVolumePanel,
+  icon,
+  onOpenLinkedVolumePanel,
+  onPower,
+}: {
+  launchFrom: "disabled" | "trailing_volume_bar_button";
+  canOpenLinkedVolumePanel: boolean;
+  icon: string;
+  onOpenLinkedVolumePanel: () => void;
+  onPower: () => void;
+}) => {
+  if (
+    launchFrom === "trailing_volume_bar_button" &&
+    canOpenLinkedVolumePanel
+  ) {
+    return (
+      <IconButton size="small" onClick={onOpenLinkedVolumePanel} icon={icon} />
+    );
+  }
+
+  return <IconButton size="small" onClick={onPower} icon="mdi:power" />;
+};

--- a/src/components/MediocreLargeMultiMediaPlayerCard/components/VolumePanelView.tsx
+++ b/src/components/MediocreLargeMultiMediaPlayerCard/components/VolumePanelView.tsx
@@ -1,0 +1,262 @@
+import { useContext, useMemo, useCallback } from "preact/hooks";
+import type {
+  LinkedVolumePanelEntity,
+  MediaPlayerEntity,
+  MediocreMultiMediaPlayerCardConfig,
+} from "@types";
+import {
+  CardContext,
+  CardContextType,
+  Icon,
+  IconButton,
+  VolumeSlider,
+  useHass,
+} from "@components";
+import { css } from "@emotion/react";
+import {
+  getCanOpenLinkedVolumePanel,
+  getDeviceIcon,
+  getHass,
+  getLinkedVolumePanelSections,
+  getVolumeIcon,
+} from "@utils";
+import { theme } from "@constants";
+import { ViewHeader } from "./ViewHeader";
+import { memo } from "preact/compat";
+import { useSelectedPlayer } from "@components/SelectedPlayerContext";
+
+const styles = {
+  root: css({
+    display: "flex",
+    flexDirection: "column",
+    gap: 16,
+    overflowY: "auto",
+    height: "100%",
+    padding: 16,
+  }),
+  group: css({
+    display: "flex",
+    flexDirection: "column",
+    gap: 10,
+  }),
+  sectionTitle: css({
+    fontSize: 15,
+    fontWeight: 600,
+    color: theme.colors.onCard,
+    margin: "4px 4px 0",
+  }),
+  entityCard: css({
+    display: "flex",
+    flexDirection: "column",
+    gap: 8,
+    borderRadius: 16,
+    padding: "10px 12px",
+    backgroundColor: "var(--ha-card-background, rgba(127, 127, 127, 0.06))",
+    borderWidth: "var(--ha-card-border-width, 1px)",
+    borderColor: "var(--ha-card-border-color,var(--divider-color,#e0e0e0))",
+    borderStyle: "var(--ha-card-border-style, solid)",
+  }),
+  entityHeader: css({
+    display: "flex",
+    alignItems: "center",
+    gap: 8,
+    minWidth: 0,
+  }),
+  entityInfo: css({
+    display: "flex",
+    flexDirection: "row",
+    alignItems: "baseline",
+    gap: 8,
+    minWidth: 0,
+    flex: 1,
+  }),
+  entityTitle: css({
+    fontSize: 15,
+    fontWeight: 600,
+    color: theme.colors.onCard,
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+  }),
+  entityMeta: css({
+    fontSize: 12,
+    color: theme.colors.onCardMuted,
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+  }),
+  controlsRow: css({
+    display: "flex",
+    alignItems: "center",
+    gap: 8,
+    width: "100%",
+  }),
+  muteButtonMuted: css({
+    opacity: 0.8,
+  }),
+  emptyState: css({
+    fontSize: 14,
+    color: theme.colors.onCardMuted,
+    lineHeight: 1.4,
+  }),
+};
+
+export type VolumePanelViewProps = {
+  onClose: () => void;
+};
+
+export const VolumePanelView = memo<VolumePanelViewProps>(({ onClose }) => {
+  const hass = useHass();
+  const { selectedPlayer } = useSelectedPlayer();
+  const { config } =
+    useContext<CardContextType<MediocreMultiMediaPlayerCardConfig>>(CardContext);
+
+  const mediaPlayer = selectedPlayer!;
+  const sections = useMemo(
+    () =>
+      getLinkedVolumePanelSections(mediaPlayer, config.media_players, hass.states),
+    [config.media_players, hass.states, mediaPlayer]
+  );
+  const canOpenLinkedVolumePanel = getCanOpenLinkedVolumePanel(
+    mediaPlayer,
+    config.media_players,
+    hass.states
+  );
+
+  const availableSections = useMemo(
+    () =>
+      sections
+        .map(section => ({
+          ...section,
+          entities: section.entities.filter(entity => !!hass.states[entity.entity_id]),
+        }))
+        .filter(section => section.entities.length > 0),
+    [hass.states, sections]
+  );
+
+  return (
+    <div css={styles.root}>
+      <ViewHeader
+        title="Volume Panel"
+        renderAction={() => (
+          <IconButton size="small" icon="mdi:close" onClick={onClose} />
+        )}
+      />
+      {sections.length === 0 ? (
+        <div css={styles.emptyState}>
+          {canOpenLinkedVolumePanel
+            ? "No linked volume entities are currently available."
+            : "No linked volume endpoints are configured for the selected player."}
+        </div>
+      ) : availableSections.length === 0 ? (
+        <div css={styles.emptyState}>
+          None of the linked volume entities are currently available.
+        </div>
+      ) : (
+        availableSections.map(section => (
+          <div css={styles.group} key={section.key}>
+            <div css={styles.sectionTitle}>
+              {(hass.states[section.key] as MediaPlayerEntity | undefined)
+                ?.attributes?.friendly_name ?? section.title}
+            </div>
+            {section.entities.map(entity => (
+              <VolumePanelEntityCard
+                key={entity.entity_id}
+                entity={entity}
+                showStepButtons={config.options?.show_volume_step_buttons ?? false}
+                useVolumeUpDownForSteps={
+                  config.options?.use_volume_up_down_for_step_buttons ?? false
+                }
+              />
+            ))}
+          </div>
+        ))
+      )}
+    </div>
+  );
+});
+
+const VolumePanelEntityCard = ({
+  entity,
+  showStepButtons,
+  useVolumeUpDownForSteps,
+}: {
+  entity: LinkedVolumePanelEntity;
+  showStepButtons: boolean;
+  useVolumeUpDownForSteps: boolean;
+}) => {
+  const hass = useHass();
+  const player = hass.states[entity.entity_id] as MediaPlayerEntity | undefined;
+
+  const volume = player?.attributes?.volume_level ?? 0;
+  const isVolumeMuted = player?.attributes?.is_volume_muted ?? false;
+  const volumeIcon = getVolumeIcon(volume, isVolumeMuted);
+  const volumePercent = Math.round(volume * 100);
+  const isOff = player?.state === "off";
+  const displayName =
+    entity.name ?? player?.attributes?.friendly_name ?? entity.entity_id;
+  const displayIcon =
+    entity.icon ??
+    getDeviceIcon({
+      icon: player?.attributes?.icon,
+      deviceClass: player?.attributes?.device_class,
+    });
+  const subtitle = isOff
+    ? "Off"
+    : `${volumePercent}%${isVolumeMuted ? " · Muted" : ""}`;
+  const showPowerButton = entity.show_power === true;
+  const isPowerOn = player?.state !== "off";
+
+  const handleToggleMute = useCallback(() => {
+    if (!player) return;
+    getHass().callService("media_player", "volume_mute", {
+      entity_id: entity.entity_id,
+      is_volume_muted: !isVolumeMuted,
+    });
+  }, [entity.entity_id, isVolumeMuted, player]);
+
+  const handleTogglePower = useCallback(() => {
+    const service = isPowerOn ? "turn_off" : "turn_on";
+    getHass().callService("media_player", service, {
+      entity_id: entity.entity_id,
+    });
+  }, [entity.entity_id, isPowerOn]);
+
+  if (!player) return null;
+
+  return (
+    <div css={styles.entityCard}>
+      <div css={styles.entityHeader}>
+        <Icon icon={displayIcon} size="x-small" />
+        <div css={styles.entityInfo}>
+          <div css={styles.entityTitle}>{displayName}</div>
+          {subtitle ? <div css={styles.entityMeta}>{subtitle}</div> : null}
+        </div>
+        {showPowerButton ? (
+          <IconButton
+            size="x-small"
+            icon="mdi:power"
+            selected={isPowerOn}
+            onClick={handleTogglePower}
+          />
+        ) : null}
+      </div>
+      <div css={styles.controlsRow}>
+        <IconButton
+          css={isVolumeMuted ? styles.muteButtonMuted : {}}
+          size="x-small"
+          onClick={handleToggleMute}
+          icon={volumeIcon}
+          disabled={isOff}
+        />
+        <VolumeSlider
+          entityId={entity.entity_id}
+          syncGroupChildren={false}
+          sliderSize="small"
+          showStepButtons={showStepButtons}
+          useVolumeUpDownForSteps={useVolumeUpDownForSteps}
+        />
+      </div>
+    </div>
+  );
+};

--- a/src/components/MediocreLargeMultiMediaPlayerCard/components/index.ts
+++ b/src/components/MediocreLargeMultiMediaPlayerCard/components/index.ts
@@ -6,4 +6,5 @@ export * from "./MediaBrowserView";
 export * from "./MiniPlayer";
 export * from "./SearchView";
 export * from "./SpeakerGrouping";
+export * from "./VolumePanelView";
 export * from "./ViewHeader";

--- a/src/components/MediocreMassiveMediaPlayerCard/MediocreMassiveMediaPlayerCardEditor.tsx
+++ b/src/components/MediocreMassiveMediaPlayerCard/MediocreMassiveMediaPlayerCardEditor.tsx
@@ -168,7 +168,8 @@ export const MediocreMassiveMediaPlayerCardEditor: FC<
         title="Music Assistant Configuration (optional)"
         error={
           getSubformError("ma_entity_id") ??
-          getSubformError("ma_favorite_button_entity_id")
+          getSubformError("ma_favorite_button_entity_id") ??
+          getSubformError("ma_favorite_control")
         }
       >
         <FieldGroupMaEntities
@@ -176,7 +177,10 @@ export const MediocreMassiveMediaPlayerCardEditor: FC<
           fields={{
             ma_entity_id: "ma_entity_id",
             ma_favorite_button_entity_id: "ma_favorite_button_entity_id",
+            ma_favorite_control: "ma_favorite_control",
           }}
+          artworkFavoriteHelperText={undefined}
+          showArtworkFavoriteControls={true}
         />
       </SubForm>
       <SubForm

--- a/src/components/MediocreMassiveMediaPlayerCard/MediocreMassiveMediaPlayerCardEditor.tsx
+++ b/src/components/MediocreMassiveMediaPlayerCard/MediocreMassiveMediaPlayerCardEditor.tsx
@@ -5,7 +5,7 @@ import {
 import { MediocreMassiveMediaPlayerCardConfig } from "@types";
 import { useCallback, useEffect } from "preact/hooks";
 import { useStore, ValidationErrorMap } from "@tanstack/react-form";
-import { FormGroup, SubForm, FormSelect } from "@components";
+import { FormGroup, SubForm, FormSelect, Label } from "@components";
 import { css } from "@emotion/react";
 import { FC } from "preact/compat";
 import {
@@ -219,6 +219,32 @@ export const MediocreMassiveMediaPlayerCardEditor: FC<
           formErrors={formErrorMap as ValidationErrorMap<unknown>}
           fields={{ custom_buttons: "custom_buttons" as never }} // todo this casting is stupid
         />
+      </SubForm>
+      <SubForm
+        title="UI Customization (optional)"
+        error={getSubformError("options.ui")}
+      >
+        <SubForm title="Footer / Navigation" error={getSubformError("options.ui.footer_icons")}>
+          <Label>Optional icon overrides for the large footer tabs.</Label>
+          <form.AppField
+            name="options.ui.footer_icons.player"
+            children={field => (
+              <field.Text label="Player / Home tab icon" isIconInput />
+            )}
+          />
+          <form.AppField
+            name="options.ui.footer_icons.search"
+            children={field => (
+              <field.Text label="Search tab icon" isIconInput />
+            )}
+          />
+          <form.AppField
+            name="options.ui.footer_icons.media_browser"
+            children={field => (
+              <field.Text label="Browse Media tab icon" isIconInput />
+            )}
+          />
+        </SubForm>
       </SubForm>
       <SubForm
         title="Additional options (optional)"

--- a/src/components/MediocreMediaPlayerCard/MediocreMediaPlayerCardEditor.tsx
+++ b/src/components/MediocreMediaPlayerCard/MediocreMediaPlayerCardEditor.tsx
@@ -64,6 +64,10 @@ export const MediocreMediaPlayerCardEditor: FC<
     },
   });
 
+  const tapOpensPopup = useStore(
+    form.store,
+    state => state.values.tap_opens_popup ?? false
+  );
   const formErrorMap = useStore(form.store, state => state.errorMap);
   const getSubformError = useCallback(
     (fieldName: string) => {
@@ -162,7 +166,8 @@ export const MediocreMediaPlayerCardEditor: FC<
         title="Music Assistant Configuration (optional)"
         error={
           getSubformError("ma_entity_id") ??
-          getSubformError("ma_favorite_button_entity_id")
+          getSubformError("ma_favorite_button_entity_id") ??
+          getSubformError("ma_favorite_control")
         }
       >
         <FieldGroupMaEntities
@@ -170,7 +175,14 @@ export const MediocreMediaPlayerCardEditor: FC<
           fields={{
             ma_entity_id: "ma_entity_id",
             ma_favorite_button_entity_id: "ma_favorite_button_entity_id",
+            ma_favorite_control: "ma_favorite_control",
           }}
+          showArtworkFavoriteControls={tapOpensPopup}
+          artworkFavoriteHelperText={
+            tapOpensPopup
+              ? "Shown on popup artwork."
+              : "Artwork favorite only appears on the popup artwork. Enable \"Tap opens popup\" to use it on this card."
+          }
         />
       </SubForm>
       <SubForm

--- a/src/components/MediocreMultiMediaPlayerCard/MediocreMultiMediaPlayerCardEditor.tsx
+++ b/src/components/MediocreMultiMediaPlayerCard/MediocreMultiMediaPlayerCardEditor.tsx
@@ -21,8 +21,10 @@ import { FieldGroupMediaBrowser } from "@components/Form/components/FieldGroupMe
 import { FieldGroupCustomButtons } from "@components/Form/components/FieldGroupCustomButtons";
 import { FieldGroupMaEntities } from "@components/Form/components/FieldGroupMaEntities";
 import { FieldGroupSearch } from "@components/Form/components/FieldGroupSearch";
+import { FieldGroupVolumePanel } from "@components/Form/components/FieldGroupVolumePanel";
 import { getSearchEntryArray } from "@utils/getSearchEntryArray";
 import { getCleanMaFavoriteControl } from "@utils/cardConfigUtils";
+import { getCleanLinkedVolumePanel } from "@utils";
 
 export type MediocreMultiMediaPlayerCardEditorProps = {
   rootElement: HTMLElement;
@@ -120,34 +122,57 @@ export const MediocreMultiMediaPlayerCardEditor: FC<
         }
         newConfig.media_players = newConfig.media_players.map(
           (player: MediocreMultiMediaPlayerCardConfig["media_players"][number]) => {
-          const maFavoriteControl = getCleanMaFavoriteControl(
-            player.ma_favorite_control
-          );
-          if (maFavoriteControl) {
-            return {
-              ...player,
-              ma_favorite_control: maFavoriteControl,
-            };
-          }
-          const { ma_favorite_control: _omit, ...rest } = player;
-          return rest;
+            const nextPlayer = { ...player };
+            const maFavoriteControl = getCleanMaFavoriteControl(
+              player.ma_favorite_control
+            );
+            const linkedVolumePanel = getCleanLinkedVolumePanel(
+              player.linked_volume_panel
+            );
+
+            if (maFavoriteControl) {
+              nextPlayer.ma_favorite_control = maFavoriteControl;
+            } else {
+              delete nextPlayer.ma_favorite_control;
+            }
+
+            if (linkedVolumePanel) {
+              nextPlayer.linked_volume_panel = linkedVolumePanel;
+            } else {
+              delete nextPlayer.linked_volume_panel;
+            }
+
+            return nextPlayer;
           }
         );
-        if (newConfig.size === "large" && newConfig.options?.ui?.footer_icons) {
-          Object.keys(newConfig.options.ui.footer_icons).forEach(key => {
-            const icon =
-              newConfig.options?.ui?.footer_icons?.[
-                key as keyof typeof newConfig.options.ui.footer_icons
-              ];
-            if (!icon?.trim()) {
-              delete newConfig.options?.ui?.footer_icons?.[
-                key as keyof typeof newConfig.options.ui.footer_icons
-              ];
+        if (newConfig.size === "large" && newConfig.options?.ui) {
+          if (newConfig.options.ui.footer_icons) {
+            Object.keys(newConfig.options.ui.footer_icons).forEach(key => {
+              const icon =
+                newConfig.options?.ui?.footer_icons?.[
+                  key as keyof typeof newConfig.options.ui.footer_icons
+                ];
+              if (!icon?.trim()) {
+                delete newConfig.options?.ui?.footer_icons?.[
+                  key as keyof typeof newConfig.options.ui.footer_icons
+                ];
+              }
+            });
+            if (Object.keys(newConfig.options.ui.footer_icons).length === 0) {
+              delete newConfig.options.ui.footer_icons;
             }
-          });
-          if (Object.keys(newConfig.options.ui.footer_icons).length === 0) {
-            delete newConfig.options.ui.footer_icons;
           }
+
+          const trailingVolumeButtonIcon =
+            newConfig.options.ui.volume_bar?.trailing_volume_button_icon?.trim();
+          if (trailingVolumeButtonIcon) {
+            newConfig.options.ui.volume_bar = {
+              trailing_volume_button_icon: trailingVolumeButtonIcon,
+            };
+          } else if (newConfig.options.ui.volume_bar) {
+            delete newConfig.options.ui.volume_bar;
+          }
+
           if (Object.keys(newConfig.options.ui).length === 0) {
             delete newConfig.options.ui;
           }
@@ -415,6 +440,24 @@ export const MediocreMultiMediaPlayerCardEditor: FC<
                           }} // todo this casting is stupid
                         />
                       </SubForm>
+                      {size === "large" ? (
+                        <SubForm
+                          title="Linked Volume Panel (optional)"
+                          error={getSubformError(
+                            `media_players[${index}].linked_volume_panel`
+                          )}
+                        >
+                          <FieldGroupVolumePanel
+                            form={form}
+                            fields={{
+                              linked_volume_panel:
+                                `media_players[${index}].linked_volume_panel` as never,
+                            }}
+                          />
+                        </SubForm>
+                      ) : (
+                        <Fragment />
+                      )}
                     </SubForm>
                   );
                 })}
@@ -605,6 +648,18 @@ export const MediocreMultiMediaPlayerCardEditor: FC<
               name="options.ui.footer_icons.media_browser"
               children={field => (
                 <field.Text label="Browse Media tab icon" isIconInput />
+              )}
+            />
+          </SubForm>
+          <SubForm
+            title="Volume Bar"
+            error={getSubformError("options.ui.volume_bar")}
+          >
+            <Label>Optional icon override for the linked volume trailing button.</Label>
+            <form.AppField
+              name="options.ui.volume_bar.trailing_volume_button_icon"
+              children={field => (
+                <field.Text label="Trailing volume button icon" isIconInput />
               )}
             />
           </SubForm>

--- a/src/components/MediocreMultiMediaPlayerCard/MediocreMultiMediaPlayerCardEditor.tsx
+++ b/src/components/MediocreMultiMediaPlayerCard/MediocreMultiMediaPlayerCardEditor.tsx
@@ -22,6 +22,7 @@ import { FieldGroupCustomButtons } from "@components/Form/components/FieldGroupC
 import { FieldGroupMaEntities } from "@components/Form/components/FieldGroupMaEntities";
 import { FieldGroupSearch } from "@components/Form/components/FieldGroupSearch";
 import { getSearchEntryArray } from "@utils/getSearchEntryArray";
+import { getCleanMaFavoriteControl } from "@utils/cardConfigUtils";
 
 export type MediocreMultiMediaPlayerCardEditorProps = {
   rootElement: HTMLElement;
@@ -117,7 +118,22 @@ export const MediocreMultiMediaPlayerCardEditor: FC<
         if (newConfig.search) {
           stripNulls(newConfig.search);
         }
-        if (newConfig.options?.ui?.footer_icons) {
+        newConfig.media_players = newConfig.media_players.map(
+          (player: MediocreMultiMediaPlayerCardConfig["media_players"][number]) => {
+          const maFavoriteControl = getCleanMaFavoriteControl(
+            player.ma_favorite_control
+          );
+          if (maFavoriteControl) {
+            return {
+              ...player,
+              ma_favorite_control: maFavoriteControl,
+            };
+          }
+          const { ma_favorite_control: _omit, ...rest } = player;
+          return rest;
+          }
+        );
+        if (newConfig.size === "large" && newConfig.options?.ui?.footer_icons) {
           Object.keys(newConfig.options.ui.footer_icons).forEach(key => {
             const icon =
               newConfig.options?.ui?.footer_icons?.[
@@ -135,6 +151,8 @@ export const MediocreMultiMediaPlayerCardEditor: FC<
           if (Object.keys(newConfig.options.ui).length === 0) {
             delete newConfig.options.ui;
           }
+        } else if (newConfig.options && "ui" in newConfig.options) {
+          delete (newConfig.options as { ui?: unknown }).ui;
         }
 
         if (formApi.state.isValid) {
@@ -150,10 +168,6 @@ export const MediocreMultiMediaPlayerCardEditor: FC<
   });
 
   const size = useStore(form.store, state => state.values.size);
-  const tapOpensPopup = useStore(form.store, state =>
-    "tap_opens_popup" in state.values ? state.values.tap_opens_popup : false
-  );
-
   const formErrorMap = useStore(form.store, state => state.errorMap);
   const getSubformError = useCallback(
     (fieldName: string) => {
@@ -316,6 +330,9 @@ export const MediocreMultiMediaPlayerCardEditor: FC<
                           ) ??
                           getSubformError(
                             `media_players[${index}].ma_favorite_button_entity_id`
+                          ) ??
+                          getSubformError(
+                            `media_players[${index}].ma_favorite_control`
                           )
                         }
                       >
@@ -324,7 +341,16 @@ export const MediocreMultiMediaPlayerCardEditor: FC<
                           fields={{
                             ma_entity_id: `media_players[${index}].ma_entity_id`,
                             ma_favorite_button_entity_id: `media_players[${index}].ma_favorite_button_entity_id`,
+                            ma_favorite_control: `media_players[${index}].ma_favorite_control`,
                           }}
+                          showArtworkFavoriteControls={
+                            size === "large"
+                          }
+                          artworkFavoriteHelperText={
+                            size === "large"
+                              ? undefined
+                              : "Artwork favorite only appears on large cards."
+                          }
                         />
                       </SubForm>
                       <SubForm
@@ -553,7 +579,7 @@ export const MediocreMultiMediaPlayerCardEditor: FC<
           </form.Field>
         </FormGroup>
       </SubForm>
-      {(size === "large" || tapOpensPopup) && (
+      {size === "large" && (
         <SubForm
           title="UI Customization (optional)"
           error={getSubformError("options.ui")}

--- a/src/components/MediocreMultiMediaPlayerCard/MediocreMultiMediaPlayerCardEditor.tsx
+++ b/src/components/MediocreMultiMediaPlayerCard/MediocreMultiMediaPlayerCardEditor.tsx
@@ -117,6 +117,25 @@ export const MediocreMultiMediaPlayerCardEditor: FC<
         if (newConfig.search) {
           stripNulls(newConfig.search);
         }
+        if (newConfig.options?.ui?.footer_icons) {
+          Object.keys(newConfig.options.ui.footer_icons).forEach(key => {
+            const icon =
+              newConfig.options?.ui?.footer_icons?.[
+                key as keyof typeof newConfig.options.ui.footer_icons
+              ];
+            if (!icon?.trim()) {
+              delete newConfig.options?.ui?.footer_icons?.[
+                key as keyof typeof newConfig.options.ui.footer_icons
+              ];
+            }
+          });
+          if (Object.keys(newConfig.options.ui.footer_icons).length === 0) {
+            delete newConfig.options.ui.footer_icons;
+          }
+          if (Object.keys(newConfig.options.ui).length === 0) {
+            delete newConfig.options.ui;
+          }
+        }
 
         if (formApi.state.isValid) {
           if (JSON.stringify(config) !== JSON.stringify(newConfig)) {
@@ -131,6 +150,9 @@ export const MediocreMultiMediaPlayerCardEditor: FC<
   });
 
   const size = useStore(form.store, state => state.values.size);
+  const tapOpensPopup = useStore(form.store, state =>
+    "tap_opens_popup" in state.values ? state.values.tap_opens_popup : false
+  );
 
   const formErrorMap = useStore(form.store, state => state.errorMap);
   const getSubformError = useCallback(
@@ -531,6 +553,37 @@ export const MediocreMultiMediaPlayerCardEditor: FC<
           </form.Field>
         </FormGroup>
       </SubForm>
+      {(size === "large" || tapOpensPopup) && (
+        <SubForm
+          title="UI Customization (optional)"
+          error={getSubformError("options.ui")}
+        >
+          <SubForm
+            title="Footer / Navigation"
+            error={getSubformError("options.ui.footer_icons")}
+          >
+            <Label>Optional icon overrides for the large footer tabs.</Label>
+            <form.AppField
+              name="options.ui.footer_icons.player"
+              children={field => (
+                <field.Text label="Player / Home tab icon" isIconInput />
+              )}
+            />
+            <form.AppField
+              name="options.ui.footer_icons.search"
+              children={field => (
+                <field.Text label="Search tab icon" isIconInput />
+              )}
+            />
+            <form.AppField
+              name="options.ui.footer_icons.media_browser"
+              children={field => (
+                <field.Text label="Browse Media tab icon" isIconInput />
+              )}
+            />
+          </SubForm>
+        </SubForm>
+      )}
     </form.AppForm>
   );
 };

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -16,6 +16,7 @@ export * from "./Input";
 export * from "./LyrionMediaBrowser";
 export * from "./MaSearch";
 export * from "./MassivePlaybackController";
+export * from "./MaFavoriteButton";
 export * from "./MediaBrowser";
 export * from "./MediaSearch";
 export * from "./MediocreChipMediaPlayerGroupCard";

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -3,6 +3,7 @@ export * from "./useArtworkColors";
 export * from "./useButtonCallbacks";
 export * from "./useCanDisplayQueue";
 export * from "./useHassMessagePromise";
+export * from "./useMaFavoriteControl";
 export * from "./useMassQueue";
 export * from "./useSqueezeboxQueue";
 export * from "./useSupportedFeatures";

--- a/src/hooks/useMaFavoriteControl.ts
+++ b/src/hooks/useMaFavoriteControl.ts
@@ -1,0 +1,286 @@
+import { useContext } from "preact/hooks";
+import { useCallback, useEffect, useMemo, useRef, useState } from "preact/hooks";
+import { CardContext, CardContextType } from "@components/CardContext";
+import { usePlayer } from "@components/PlayerContext";
+import { SelectedPlayerContext } from "@components/SelectedPlayerContext";
+import { getHasMassFeatures, getHass } from "@utils";
+import { useHassMessagePromise } from "./useHassMessagePromise";
+import type { MaFavoriteControl } from "@types";
+
+type MaFavoriteQueueResponse = Record<
+  string,
+  {
+    current_item?: {
+      queue_item_id?: string;
+      media_item?: {
+        favorite?: boolean;
+        uri?: string;
+      };
+    };
+  }
+>;
+
+type FavoriteAwareCardConfig = {
+  ma_entity_id?: string | null;
+  ma_favorite_button_entity_id?: string | null;
+  ma_favorite_control?: MaFavoriteControl;
+};
+
+const ENABLE_BACKGROUND_FAVORITE_POLLING = true;
+const FAVORITE_POLL_INTERVAL_MS = 10000;
+const CLICK_BUSY_DELAY_MS = 120;
+
+const matchesEntityId = (value: unknown, entityId: string) => {
+  if (typeof value === "string") {
+    return value === entityId;
+  }
+
+  if (Array.isArray(value)) {
+    return value.includes(entityId);
+  }
+
+  return false;
+};
+
+const sleep = (ms: number) =>
+  new Promise(resolve => window.setTimeout(resolve, ms));
+
+export const useMaFavoriteControl = () => {
+  const player = usePlayer();
+  const selectedPlayerContext = useContext(SelectedPlayerContext);
+  const { config } = useContext<CardContextType<FavoriteAwareCardConfig>>(
+    CardContext
+  );
+
+  const selectedPlayer = selectedPlayerContext?.selectedPlayer;
+  const maEntityId = selectedPlayer?.ma_entity_id ?? config.ma_entity_id;
+  const favoriteButtonEntityId =
+    selectedPlayer?.ma_favorite_button_entity_id ??
+    config.ma_favorite_button_entity_id;
+  const controlConfig =
+    selectedPlayer?.ma_favorite_control ?? config.ma_favorite_control;
+
+  const hasMassFeatures = getHasMassFeatures(
+    player.entity_id,
+    maEntityId ?? undefined
+  );
+  const enabled =
+    controlConfig?.show_on_artwork === true &&
+    hasMassFeatures &&
+    !!maEntityId &&
+    !!favoriteButtonEntityId;
+
+  const queueMessage = useMemo(
+    () =>
+      enabled
+        ? {
+            type: "call_service" as const,
+            domain: "music_assistant",
+            service: "get_queue",
+            service_data: {
+              entity_id: maEntityId,
+            },
+            return_response: true,
+          }
+        : null,
+    [enabled, maEntityId]
+  );
+
+  const queueQueryOptions = useMemo(
+    () => ({
+      enabled,
+      staleTime: 5000,
+    }),
+    [enabled]
+  );
+
+  const { data, refetch } =
+    useHassMessagePromise<MaFavoriteQueueResponse>(
+      queueMessage,
+      queueQueryOptions
+    );
+
+  const currentItem = maEntityId ? data?.[maEntityId]?.current_item : undefined;
+  const currentItemUri = currentItem?.media_item?.uri;
+  const backendFavorite = currentItem?.media_item?.favorite ?? false;
+  const isLibraryItem = !!currentItemUri?.startsWith("library://");
+
+  const [isToggling, setIsToggling] = useState(false);
+  const [overrideFavorite, setOverrideFavorite] = useState<boolean | null>(null);
+  const previousQueueFavoriteRef = useRef<boolean | null>(null);
+  const previousQueueItemIdRef = useRef<string | undefined>(undefined);
+
+  useEffect(() => {
+    if (
+      previousQueueItemIdRef.current &&
+      currentItem?.queue_item_id !== previousQueueItemIdRef.current
+    ) {
+      setOverrideFavorite(null);
+    }
+
+    previousQueueItemIdRef.current = currentItem?.queue_item_id;
+  }, [currentItem?.queue_item_id]);
+
+  useEffect(() => {
+    if (
+      previousQueueFavoriteRef.current !== null &&
+      previousQueueFavoriteRef.current !== backendFavorite
+    ) {
+      setOverrideFavorite(null);
+    }
+
+    previousQueueFavoriteRef.current = backendFavorite;
+  }, [backendFavorite]);
+
+  const refreshFavorite = useCallback(async () => {
+    await refetch();
+  }, [refetch]);
+
+  useEffect(() => {
+    if (!enabled) return;
+    void refreshFavorite();
+  }, [
+    enabled,
+    player.attributes.media_content_id,
+    player.attributes.media_title,
+    player.attributes.media_artist,
+    refreshFavorite,
+  ]);
+
+  useEffect(() => {
+    if (!ENABLE_BACKGROUND_FAVORITE_POLLING || !enabled || isToggling) {
+      return;
+    }
+
+    const intervalId = window.setInterval(() => {
+      void refreshFavorite();
+    }, FAVORITE_POLL_INTERVAL_MS);
+
+    return () => window.clearInterval(intervalId);
+  }, [enabled, isToggling, refreshFavorite]);
+
+  useEffect(() => {
+    if (!enabled || !maEntityId || !favoriteButtonEntityId) {
+      return;
+    }
+
+    let unsubscribe: (() => void) | undefined;
+    let cancelled = false;
+
+    const subscribeToFavoriteEvents = async () => {
+      unsubscribe = await getHass().connection.subscribeEvents(
+        (event: {
+          data?: {
+            domain?: string;
+            service?: string;
+            service_data?: {
+              entity?: unknown;
+              entity_id?: unknown;
+            };
+          };
+        }) => {
+          const domain = event.data?.domain;
+          const service = event.data?.service;
+          const serviceData = event.data?.service_data;
+
+          const favoriteButtonPressed =
+            domain === "button" &&
+            service === "press" &&
+            matchesEntityId(serviceData?.entity_id, favoriteButtonEntityId);
+
+          const queueUnfavorited =
+            domain === "mass_queue" &&
+            service === "unfavorite_current_item" &&
+            matchesEntityId(serviceData?.entity, maEntityId);
+
+          if (!favoriteButtonPressed && !queueUnfavorited) {
+            return;
+          }
+
+          setOverrideFavorite(favoriteButtonPressed);
+          void refreshFavorite();
+        },
+        "call_service"
+      );
+
+      if (cancelled && unsubscribe) {
+        unsubscribe();
+      }
+    };
+
+    void subscribeToFavoriteEvents();
+
+    return () => {
+      cancelled = true;
+      unsubscribe?.();
+    };
+  }, [enabled, favoriteButtonEntityId, maEntityId, refreshFavorite]);
+
+  const toggleFavorite = useCallback(async () => {
+    if (!enabled || !maEntityId || !favoriteButtonEntityId || isToggling) {
+      return;
+    }
+
+    const shouldFavorite = !(overrideFavorite ?? backendFavorite);
+
+    setIsToggling(true);
+    setOverrideFavorite(shouldFavorite);
+
+    try {
+      await sleep(CLICK_BUSY_DELAY_MS);
+
+      if (shouldFavorite) {
+        await getHass().callService("button", "press", {
+          entity_id: favoriteButtonEntityId,
+        });
+      } else {
+        await getHass().callService("mass_queue", "unfavorite_current_item", {
+          entity: maEntityId,
+        });
+      }
+
+      await refreshFavorite();
+    } finally {
+      setIsToggling(false);
+    }
+  }, [
+    backendFavorite,
+    enabled,
+    favoriteButtonEntityId,
+    isToggling,
+    maEntityId,
+    overrideFavorite,
+    refreshFavorite,
+  ]);
+
+  return useMemo(
+    () => ({
+      activeColor: controlConfig?.active_color?.trim() || "#f2c94c",
+      enabled,
+      favoriteButtonOffset:
+        controlConfig?.favorite_button_offset?.trim() || "14px",
+      favoriteButtonSize: controlConfig?.favorite_button_size ?? "small",
+      isLibraryItem,
+      inactiveColor: controlConfig?.inactive_color?.trim() || "#111111",
+      isFavorite: overrideFavorite ?? backendFavorite,
+      isLoading: isToggling,
+      toggleFavorite,
+      unsupportedMessage:
+        !isLibraryItem && (overrideFavorite ?? backendFavorite)
+          ? "Unfavorite is only available for library tracks."
+          : undefined,
+    }),
+    [
+      backendFavorite,
+      controlConfig?.active_color,
+      controlConfig?.favorite_button_offset,
+      controlConfig?.favorite_button_size,
+      controlConfig?.inactive_color,
+      enabled,
+      isLibraryItem,
+      isToggling,
+      overrideFavorite,
+      toggleFavorite,
+    ]
+  );
+};

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -11,12 +11,31 @@ const uiCustomizationSchema = type({
   "footer_icons?": footerIconsSchema, // Override footer/navigation tab icons
 });
 
+const multiLargeUiCustomizationSchema = uiCustomizationSchema.and({
+  "volume_bar?": {
+    "trailing_volume_button_icon?": "string", // Override the linked volume trailing button icon
+  },
+});
+
 const maFavoriteControlSchema = type({
   "show_on_artwork?": "boolean | null",
   "favorite_button_size?": "'small' | 'medium' | 'large'",
   "favorite_button_offset?": "string",
   "active_color?": "string",
   "inactive_color?": "string",
+});
+
+const linkedVolumePanelEntitySchema = type({
+  entity_id: "string",
+  "name?": "string | null",
+  "icon?": "string | null",
+  "show_power?": "boolean | null",
+});
+
+const linkedVolumePanelSchema = type({
+  "launch_from?": "'disabled' | 'trailing_volume_bar_button'",
+  "include_grouped_players?": "boolean | null",
+  entities: linkedVolumePanelEntitySchema.array(),
 });
 
 const commonMediocreMediaPlayerCardConfigOptionsSchema = type({
@@ -126,6 +145,7 @@ export const MediocreMultiMediaPlayer = type({
   "lms_entity_id?": type("string").or("null").or("undefined"), // LMS entity_id (adds LMS specific features)
   "search?": searchConfig,
   "media_browser?": mediaBrowser,
+  "linked_volume_panel?": linkedVolumePanelSchema.or("undefined"),
   "action?": interactionConfigSchema,
 });
 
@@ -154,7 +174,7 @@ export const MediocreMultiMediaPlayerCardConfigSchema =
       "height?": "number | string", // height of the card (can be a number in px or a string with any css unit)
       "options?": commonMediaPlayerCardOptions.and({
         "hide_selected_player_header?": "boolean", // Hide the header of the selected player in the massive view
-        "ui?": uiCustomizationSchema, // UI customization overrides
+        "ui?": multiLargeUiCustomizationSchema, // UI customization overrides
         "transparent_background_on_home?": "boolean", // Makes the background transparent when the showing the massive player
         "default_tab?":
           "'massive'|'search'|'media-browser'|'speaker-grouping'|'custom-buttons'|'queue'", // The tab to show by default when the card loads
@@ -175,6 +195,8 @@ export const MediocreMultiMediaPlayerCardConfigSchema =
 
 export type SearchMediaType = typeof searchMediaTypeSchema.infer;
 export type MaFavoriteControl = typeof maFavoriteControlSchema.infer;
+export type LinkedVolumePanel = typeof linkedVolumePanelSchema.infer;
+export type LinkedVolumePanelEntity = typeof linkedVolumePanelEntitySchema.infer;
 export type CommonMediocreMediaPlayerCardConfig =
   typeof commonMediocreMediaPlayerCardConfigSchema.infer;
 export type MediocreMediaPlayerCardConfig =

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -11,9 +11,16 @@ const uiCustomizationSchema = type({
   "footer_icons?": footerIconsSchema, // Override footer/navigation tab icons
 });
 
+const maFavoriteControlSchema = type({
+  "show_on_artwork?": "boolean | null",
+  "favorite_button_size?": "'small' | 'medium' | 'large'",
+  "favorite_button_offset?": "string",
+  "active_color?": "string",
+  "inactive_color?": "string",
+});
+
 const commonMediocreMediaPlayerCardConfigOptionsSchema = type({
   "always_show_power_button?": "boolean | null", // Always show the power button, even if the media player is on
-  "ui?": uiCustomizationSchema, // UI customization overrides
   "show_volume_step_buttons?": "boolean", // Show volume step buttons + - on volume sliders
   "use_volume_up_down_for_step_buttons?": "boolean", // Use volume_up and volume_down services for step buttons instead of setting volume using set_volume. This breaks volume sync when step buttons are used.
   "use_experimental_lms_media_browser?": "boolean", // Use the experimental LMS media browser instead of the default one when an LMS entity is used and lyrion_cli integration is present.
@@ -80,6 +87,7 @@ const commonMediocreMediaPlayerCardConfigSchema = type({
   "custom_buttons?": customButtons,
   "ma_entity_id?": type("string").or("null").or("undefined"), // MusicAssistant entity_id (adds MA specific features (currently search))
   "ma_favorite_button_entity_id?": type("string").or("null").or("undefined"), // MusicAssistant button entity to mark current song as favorite
+  "ma_favorite_control?": maFavoriteControlSchema,
   "lms_entity_id?": type("string").or("null").or("undefined"), // LMS entity_id (adds LMS specific features)
   "search?": searchConfig,
   "media_browser?": mediaBrowser,
@@ -101,6 +109,9 @@ export const MediocreMediaPlayerCardConfigSchema =
 export const MediocreMassiveMediaPlayerCardConfigSchema =
   commonMediocreMediaPlayerCardConfigSchema.and({
     mode: "'panel'|'card'|'in-card'|'popup'", // don't document popup and multi as they are only for internal use
+    "options?": commonMediocreMediaPlayerCardConfigOptionsSchema.and({
+      "ui?": uiCustomizationSchema, // UI customization overrides
+    }),
   });
 
 export const MediocreMultiMediaPlayer = type({
@@ -111,6 +122,7 @@ export const MediocreMultiMediaPlayer = type({
   "can_be_grouped?": "boolean | null",
   "ma_entity_id?": type("string").or("null").or("undefined"), // MusicAssistant entity_id (adds MA specific features (currently search))
   "ma_favorite_button_entity_id?": type("string").or("null").or("undefined"), // MusicAssistant button entity to mark current song as favorite
+  "ma_favorite_control?": maFavoriteControlSchema,
   "lms_entity_id?": type("string").or("null").or("undefined"), // LMS entity_id (adds LMS specific features)
   "search?": searchConfig,
   "media_browser?": mediaBrowser,
@@ -119,7 +131,6 @@ export const MediocreMultiMediaPlayer = type({
 
 export const commonMediaPlayerCardOptions = type({
   "player_is_active_when?": "'playing' | 'playing_or_paused'", // When to consider a media player as active.
-  "ui?": uiCustomizationSchema, // UI customization overrides
   "show_volume_step_buttons?": "boolean", // Show volume step buttons + - on volume sliders
   "use_volume_up_down_for_step_buttons?": "boolean", // Use volume_up and volume_down services for step buttons instead of setting volume using set_volume. This breaks volume sync when step buttons are used.
   "use_experimental_lms_media_browser?": "boolean", // Use the experimental LMS media browser instead of the default one when an LMS entity is used and lyrion_cli integration is present.
@@ -143,6 +154,7 @@ export const MediocreMultiMediaPlayerCardConfigSchema =
       "height?": "number | string", // height of the card (can be a number in px or a string with any css unit)
       "options?": commonMediaPlayerCardOptions.and({
         "hide_selected_player_header?": "boolean", // Hide the header of the selected player in the massive view
+        "ui?": uiCustomizationSchema, // UI customization overrides
         "transparent_background_on_home?": "boolean", // Makes the background transparent when the showing the massive player
         "default_tab?":
           "'massive'|'search'|'media-browser'|'speaker-grouping'|'custom-buttons'|'queue'", // The tab to show by default when the card loads
@@ -162,6 +174,7 @@ export const MediocreMultiMediaPlayerCardConfigSchema =
   );
 
 export type SearchMediaType = typeof searchMediaTypeSchema.infer;
+export type MaFavoriteControl = typeof maFavoriteControlSchema.infer;
 export type CommonMediocreMediaPlayerCardConfig =
   typeof commonMediocreMediaPlayerCardConfigSchema.infer;
 export type MediocreMediaPlayerCardConfig =

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -1,8 +1,19 @@
 import { type } from "arktype";
 import { interactionConfigSchema } from "./actionTypes";
 
+const footerIconsSchema = type({
+  "player?": "string",
+  "search?": "string",
+  "media_browser?": "string",
+});
+
+const uiCustomizationSchema = type({
+  "footer_icons?": footerIconsSchema, // Override footer/navigation tab icons
+});
+
 const commonMediocreMediaPlayerCardConfigOptionsSchema = type({
   "always_show_power_button?": "boolean | null", // Always show the power button, even if the media player is on
+  "ui?": uiCustomizationSchema, // UI customization overrides
   "show_volume_step_buttons?": "boolean", // Show volume step buttons + - on volume sliders
   "use_volume_up_down_for_step_buttons?": "boolean", // Use volume_up and volume_down services for step buttons instead of setting volume using set_volume. This breaks volume sync when step buttons are used.
   "use_experimental_lms_media_browser?": "boolean", // Use the experimental LMS media browser instead of the default one when an LMS entity is used and lyrion_cli integration is present.
@@ -108,6 +119,7 @@ export const MediocreMultiMediaPlayer = type({
 
 export const commonMediaPlayerCardOptions = type({
   "player_is_active_when?": "'playing' | 'playing_or_paused'", // When to consider a media player as active.
+  "ui?": uiCustomizationSchema, // UI customization overrides
   "show_volume_step_buttons?": "boolean", // Show volume step buttons + - on volume sliders
   "use_volume_up_down_for_step_buttons?": "boolean", // Use volume_up and volume_down services for step buttons instead of setting volume using set_volume. This breaks volume sync when step buttons are used.
   "use_experimental_lms_media_browser?": "boolean", // Use the experimental LMS media browser instead of the default one when an LMS entity is used and lyrion_cli integration is present.

--- a/src/utils/cardConfigUtils.test.ts
+++ b/src/utils/cardConfigUtils.test.ts
@@ -126,6 +126,12 @@ describe("cardConfigUtils", () => {
           always_show_custom_buttons: true,
           hide_when_group_child: true,
           hide_when_off: true,
+          ui: {
+            footer_icons: {
+              player: "mdi:play-circle",
+              media_browser: "mdi:bookshelf",
+            },
+          },
           show_volume_step_buttons: true,
           use_volume_up_down_for_step_buttons: true,
           use_experimental_lms_media_browser: false,
@@ -363,6 +369,41 @@ describe("cardConfigUtils", () => {
         media_browser: { enabled: true },
       });
     });
+
+    it("should preserve non-empty footer icon overrides and drop empty ones", () => {
+      const configWithFooterIcons: MediocreMediaPlayerCardConfig = {
+        type: "custom:mediocre-media-player-card",
+        entity_id: "media_player.test",
+        use_art_colors: false,
+        tap_opens_popup: false,
+        action: {},
+        speaker_group: { entity_id: null, entities: [] },
+        search: { enabled: false, show_favorites: false, entity_id: null },
+        ma_entity_id: null,
+        custom_buttons: [],
+        options: {
+          always_show_power_button: false,
+          always_show_custom_buttons: false,
+          ui: {
+            footer_icons: {
+              player: "mdi:play",
+              search: " ",
+            },
+          },
+        },
+        media_browser: { enabled: false },
+      };
+
+      const result = getSimpleConfigFromFormValues(configWithFooterIcons);
+
+      expect(result.options).toEqual({
+        ui: {
+          footer_icons: {
+            player: "mdi:play",
+          },
+        },
+      });
+    });
   });
 
   describe("getSimpleConfigFromMassiveFormValues", () => {
@@ -448,6 +489,42 @@ describe("cardConfigUtils", () => {
         mode: "card",
         grid_options: { columns: "full" },
         media_browser: { enabled: true },
+      });
+    });
+
+    it("should preserve non-empty footer icon overrides and drop empty ones", () => {
+      const configWithFooterIcons: MediocreMassiveMediaPlayerCardConfig = {
+        type: "custom:mediocre-massive-media-player-card",
+        entity_id: "media_player.test",
+        mode: "card",
+        use_art_colors: false,
+        action: {},
+        speaker_group: { entity_id: null, entities: [] },
+        search: { enabled: false, show_favorites: false, entity_id: null },
+        ma_entity_id: null,
+        custom_buttons: [],
+        options: {
+          always_show_power_button: false,
+          ui: {
+            footer_icons: {
+              media_browser: "mdi:playlist-music",
+              search: "",
+            },
+          },
+        },
+        media_browser: { enabled: false },
+      };
+
+      const result = getSimpleConfigFromMassiveFormValues(
+        configWithFooterIcons
+      );
+
+      expect(result.options).toEqual({
+        ui: {
+          footer_icons: {
+            media_browser: "mdi:playlist-music",
+          },
+        },
       });
     });
   });

--- a/src/utils/cardConfigUtils.test.ts
+++ b/src/utils/cardConfigUtils.test.ts
@@ -126,12 +126,6 @@ describe("cardConfigUtils", () => {
           always_show_custom_buttons: true,
           hide_when_group_child: true,
           hide_when_off: true,
-          ui: {
-            footer_icons: {
-              player: "mdi:play-circle",
-              media_browser: "mdi:bookshelf",
-            },
-          },
           show_volume_step_buttons: true,
           use_volume_up_down_for_step_buttons: true,
           use_experimental_lms_media_browser: false,
@@ -370,40 +364,6 @@ describe("cardConfigUtils", () => {
       });
     });
 
-    it("should preserve non-empty footer icon overrides and drop empty ones", () => {
-      const configWithFooterIcons: MediocreMediaPlayerCardConfig = {
-        type: "custom:mediocre-media-player-card",
-        entity_id: "media_player.test",
-        use_art_colors: false,
-        tap_opens_popup: false,
-        action: {},
-        speaker_group: { entity_id: null, entities: [] },
-        search: { enabled: false, show_favorites: false, entity_id: null },
-        ma_entity_id: null,
-        custom_buttons: [],
-        options: {
-          always_show_power_button: false,
-          always_show_custom_buttons: false,
-          ui: {
-            footer_icons: {
-              player: "mdi:play",
-              search: " ",
-            },
-          },
-        },
-        media_browser: { enabled: false },
-      };
-
-      const result = getSimpleConfigFromFormValues(configWithFooterIcons);
-
-      expect(result.options).toEqual({
-        ui: {
-          footer_icons: {
-            player: "mdi:play",
-          },
-        },
-      });
-    });
   });
 
   describe("getSimpleConfigFromMassiveFormValues", () => {

--- a/src/utils/cardConfigUtils.ts
+++ b/src/utils/cardConfigUtils.ts
@@ -1,4 +1,5 @@
 import {
+  MaFavoriteControl,
   MediocreMediaPlayerCardConfig,
   MediocreMassiveMediaPlayerCardConfig,
 } from "@types";
@@ -12,6 +13,33 @@ const getCleanFooterIcons = (
   );
 
   return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+};
+
+export const getCleanMaFavoriteControl = (
+  control?: MaFavoriteControl | null
+): MaFavoriteControl | undefined => {
+  if (!control?.show_on_artwork) return undefined;
+
+  const activeColor = control.active_color?.trim();
+  const favoriteButtonOffset = control.favorite_button_offset?.trim();
+  const inactiveColor = control.inactive_color?.trim();
+
+  return {
+    show_on_artwork: true,
+    ...(control.favorite_button_size &&
+    control.favorite_button_size !== "small"
+      ? { favorite_button_size: control.favorite_button_size }
+      : {}),
+    ...(favoriteButtonOffset && favoriteButtonOffset !== "14px"
+      ? { favorite_button_offset: favoriteButtonOffset }
+      : {}),
+    ...(activeColor && activeColor !== "#f2c94c"
+      ? { active_color: activeColor }
+      : {}),
+    ...(inactiveColor && inactiveColor !== "#111111"
+      ? { inactive_color: inactiveColor }
+      : {}),
+  };
 };
 
 /**
@@ -38,6 +66,9 @@ export const getDefaultValuesFromConfig = (
     : null,
   ma_entity_id: config?.ma_entity_id ?? null,
   ma_favorite_button_entity_id: config?.ma_favorite_button_entity_id ?? null,
+  ...(config?.ma_favorite_control
+    ? { ma_favorite_control: { ...config.ma_favorite_control } }
+    : {}),
   lms_entity_id: config?.lms_entity_id ?? null,
   custom_buttons: config?.custom_buttons ?? [],
   options: {
@@ -51,15 +82,6 @@ export const getDefaultValuesFromConfig = (
       config?.options?.show_volume_step_buttons ?? false,
     use_volume_up_down_for_step_buttons:
       config?.options?.use_volume_up_down_for_step_buttons ?? false,
-    ...(config?.options?.ui?.footer_icons
-      ? {
-          ui: {
-            footer_icons: {
-              ...config.options.ui.footer_icons,
-            },
-          },
-        }
-      : {}),
     use_experimental_lms_media_browser:
       config?.options?.use_experimental_lms_media_browser ?? false,
   },
@@ -90,6 +112,9 @@ export const getDefaultValuesFromMassiveConfig = (
     : null,
   ma_entity_id: config?.ma_entity_id ?? null,
   ma_favorite_button_entity_id: config?.ma_favorite_button_entity_id ?? null,
+  ...(config?.ma_favorite_control
+    ? { ma_favorite_control: { ...config.ma_favorite_control } }
+    : {}),
   lms_entity_id: config?.lms_entity_id ?? null,
   custom_buttons: config?.custom_buttons ?? [],
   options: {
@@ -136,6 +161,12 @@ export const getSimpleConfigFromFormValues = (
   if (!config.ma_favorite_button_entity_id) {
     delete config.ma_favorite_button_entity_id;
   }
+  const maFavoriteControl = getCleanMaFavoriteControl(config.ma_favorite_control);
+  if (maFavoriteControl) {
+    config.ma_favorite_control = maFavoriteControl;
+  } else {
+    delete config.ma_favorite_control;
+  }
 
   if (!config.lms_entity_id) delete config.lms_entity_id;
   if (!config.custom_buttons || config.custom_buttons.length === 0)
@@ -173,25 +204,9 @@ export const getSimpleConfigFromFormValues = (
   if (config.options?.use_volume_up_down_for_step_buttons === false) {
     delete config.options.use_volume_up_down_for_step_buttons;
   }
-  const footerIcons = getCleanFooterIcons(config.options?.ui?.footer_icons);
-  if (footerIcons) {
-    config.options = {
-      ...config.options,
-      ui: {
-        ...config.options?.ui,
-        footer_icons: footerIcons,
-      },
-    };
-  } else if (config.options?.ui?.footer_icons) {
-    delete config.options.ui.footer_icons;
-  }
-  if (config.options?.ui && Object.keys(config.options.ui).length === 0) {
-    delete config.options.ui;
-  }
   if (config.options?.use_experimental_lms_media_browser === false) {
     delete config.options.use_experimental_lms_media_browser;
   }
-
   if (Object.keys(config.options ?? {}).length === 0) {
     delete config.options;
   }
@@ -226,6 +241,12 @@ export const getSimpleConfigFromMassiveFormValues = (
   // Only preserve ma_favorite_button_entity_id if it is a non-empty string
   if (!config.ma_favorite_button_entity_id) {
     delete config.ma_favorite_button_entity_id;
+  }
+  const maFavoriteControl = getCleanMaFavoriteControl(config.ma_favorite_control);
+  if (maFavoriteControl) {
+    config.ma_favorite_control = maFavoriteControl;
+  } else {
+    delete config.ma_favorite_control;
   }
 
   if (!config.lms_entity_id) delete config.lms_entity_id;

--- a/src/utils/cardConfigUtils.ts
+++ b/src/utils/cardConfigUtils.ts
@@ -4,6 +4,16 @@ import {
 } from "@types";
 import { getSearchEntryArray } from "./getSearchEntryArray";
 
+const getCleanFooterIcons = (
+  footerIcons?: Record<string, string | undefined>
+) => {
+  const entries = Object.entries(footerIcons ?? {}).filter(
+    ([, icon]) => !!icon?.trim()
+  );
+
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+};
+
 /**
  * Creates default values from a regular media player card config
  */
@@ -41,6 +51,15 @@ export const getDefaultValuesFromConfig = (
       config?.options?.show_volume_step_buttons ?? false,
     use_volume_up_down_for_step_buttons:
       config?.options?.use_volume_up_down_for_step_buttons ?? false,
+    ...(config?.options?.ui?.footer_icons
+      ? {
+          ui: {
+            footer_icons: {
+              ...config.options.ui.footer_icons,
+            },
+          },
+        }
+      : {}),
     use_experimental_lms_media_browser:
       config?.options?.use_experimental_lms_media_browser ?? false,
   },
@@ -80,6 +99,15 @@ export const getDefaultValuesFromMassiveConfig = (
       config?.options?.show_volume_step_buttons ?? false,
     use_volume_up_down_for_step_buttons:
       config?.options?.use_volume_up_down_for_step_buttons ?? false,
+    ...(config?.options?.ui?.footer_icons
+      ? {
+          ui: {
+            footer_icons: {
+              ...config.options.ui.footer_icons,
+            },
+          },
+        }
+      : {}),
     use_experimental_lms_media_browser:
       config?.options?.use_experimental_lms_media_browser ?? false,
   },
@@ -144,6 +172,21 @@ export const getSimpleConfigFromFormValues = (
   }
   if (config.options?.use_volume_up_down_for_step_buttons === false) {
     delete config.options.use_volume_up_down_for_step_buttons;
+  }
+  const footerIcons = getCleanFooterIcons(config.options?.ui?.footer_icons);
+  if (footerIcons) {
+    config.options = {
+      ...config.options,
+      ui: {
+        ...config.options?.ui,
+        footer_icons: footerIcons,
+      },
+    };
+  } else if (config.options?.ui?.footer_icons) {
+    delete config.options.ui.footer_icons;
+  }
+  if (config.options?.ui && Object.keys(config.options.ui).length === 0) {
+    delete config.options.ui;
   }
   if (config.options?.use_experimental_lms_media_browser === false) {
     delete config.options.use_experimental_lms_media_browser;
@@ -210,6 +253,21 @@ export const getSimpleConfigFromMassiveFormValues = (
   }
   if (config.options?.use_volume_up_down_for_step_buttons === false) {
     delete config.options.use_volume_up_down_for_step_buttons;
+  }
+  const footerIcons = getCleanFooterIcons(config.options?.ui?.footer_icons);
+  if (footerIcons) {
+    config.options = {
+      ...config.options,
+      ui: {
+        ...config.options?.ui,
+        footer_icons: footerIcons,
+      },
+    };
+  } else if (config.options?.ui?.footer_icons) {
+    delete config.options.ui.footer_icons;
+  }
+  if (config.options?.ui && Object.keys(config.options.ui).length === 0) {
+    delete config.options.ui;
   }
   if (config.options?.use_experimental_lms_media_browser === false) {
     delete config.options.use_experimental_lms_media_browser;

--- a/src/utils/getMediocreLegacyConfigToMultiConfig.test.ts
+++ b/src/utils/getMediocreLegacyConfigToMultiConfig.test.ts
@@ -43,12 +43,6 @@ describe("getMediocreLegacyConfigToMediocreMultiConfig", () => {
       always_show_power_button: false,
       hide_when_group_child: false,
       hide_when_off: false,
-      ui: {
-        footer_icons: {
-          player: "mdi:play-circle",
-          media_browser: "mdi:bookshelf",
-        },
-      },
     },
   };
 
@@ -69,12 +63,6 @@ describe("getMediocreLegacyConfigToMediocreMultiConfig", () => {
           always_show_power_button: false,
           hide_when_group_child: false,
           hide_when_off: false,
-          ui: {
-            footer_icons: {
-              player: "mdi:play-circle",
-              media_browser: "mdi:bookshelf",
-            },
-          },
         }),
         media_players: [
           expect.objectContaining({

--- a/src/utils/getMediocreLegacyConfigToMultiConfig.test.ts
+++ b/src/utils/getMediocreLegacyConfigToMultiConfig.test.ts
@@ -43,6 +43,12 @@ describe("getMediocreLegacyConfigToMediocreMultiConfig", () => {
       always_show_power_button: false,
       hide_when_group_child: false,
       hide_when_off: false,
+      ui: {
+        footer_icons: {
+          player: "mdi:play-circle",
+          media_browser: "mdi:bookshelf",
+        },
+      },
     },
   };
 
@@ -63,6 +69,12 @@ describe("getMediocreLegacyConfigToMediocreMultiConfig", () => {
           always_show_power_button: false,
           hide_when_group_child: false,
           hide_when_off: false,
+          ui: {
+            footer_icons: {
+              player: "mdi:play-circle",
+              media_browser: "mdi:bookshelf",
+            },
+          },
         }),
         media_players: [
           expect.objectContaining({

--- a/src/utils/getMediocreLegacyConfigToMultiConfig.ts
+++ b/src/utils/getMediocreLegacyConfigToMultiConfig.ts
@@ -57,6 +57,15 @@ export const getMediocreLegacyConfigToMediocreMultiConfig = (
         config.options?.show_volume_step_buttons ?? false,
       use_volume_up_down_for_step_buttons:
         config.options?.use_volume_up_down_for_step_buttons ?? false,
+      ...(config.options?.ui?.footer_icons
+        ? {
+            ui: {
+              footer_icons: {
+                ...config.options.ui.footer_icons,
+              },
+            },
+          }
+        : {}),
       always_show_custom_buttons:
         config.options?.always_show_custom_buttons ?? false,
       always_show_power_button:

--- a/src/utils/getMediocreLegacyConfigToMultiConfig.ts
+++ b/src/utils/getMediocreLegacyConfigToMultiConfig.ts
@@ -13,6 +13,7 @@ export const getMediocreLegacyConfigToMediocreMultiConfig = (
       entity_id: config.entity_id,
       ma_entity_id: config.ma_entity_id,
       ma_favorite_button_entity_id: config.ma_favorite_button_entity_id,
+      ma_favorite_control: config.ma_favorite_control,
       speaker_group_entity_id: config.speaker_group?.entity_id,
       lms_entity_id: config.lms_entity_id,
       search: config.search,
@@ -57,15 +58,6 @@ export const getMediocreLegacyConfigToMediocreMultiConfig = (
         config.options?.show_volume_step_buttons ?? false,
       use_volume_up_down_for_step_buttons:
         config.options?.use_volume_up_down_for_step_buttons ?? false,
-      ...(config.options?.ui?.footer_icons
-        ? {
-            ui: {
-              footer_icons: {
-                ...config.options.ui.footer_icons,
-              },
-            },
-          }
-        : {}),
       always_show_custom_buttons:
         config.options?.always_show_custom_buttons ?? false,
       always_show_power_button:

--- a/src/utils/getMediocreMassiveLegacyConfigToMultiConfig.ts
+++ b/src/utils/getMediocreMassiveLegacyConfigToMultiConfig.ts
@@ -58,6 +58,15 @@ export const getMediocreMassiveLegacyConfigToMediocreMultiConfig = (
         config.options?.show_volume_step_buttons ?? false,
       use_volume_up_down_for_step_buttons:
         config.options?.use_volume_up_down_for_step_buttons ?? false,
+      ...(config.options?.ui?.footer_icons
+        ? {
+            ui: {
+              footer_icons: {
+                ...config.options.ui.footer_icons,
+              },
+            },
+          }
+        : {}),
       transparent_background_on_home:
         config.mode === "panel" ||
         config.mode === "in-card" ||

--- a/src/utils/getMediocreMassiveLegacyConfigToMultiConfig.ts
+++ b/src/utils/getMediocreMassiveLegacyConfigToMultiConfig.ts
@@ -13,6 +13,7 @@ export const getMediocreMassiveLegacyConfigToMediocreMultiConfig = (
       entity_id: config.entity_id,
       ma_entity_id: config.ma_entity_id,
       ma_favorite_button_entity_id: config.ma_favorite_button_entity_id,
+      ma_favorite_control: config.ma_favorite_control,
       speaker_group_entity_id: config.speaker_group?.entity_id,
       lms_entity_id: config.lms_entity_id,
       search: config.search,

--- a/src/utils/getMultiConfigToMediocreMassiveConfig.test.ts
+++ b/src/utils/getMultiConfigToMediocreMassiveConfig.test.ts
@@ -51,6 +51,12 @@ describe("getMultiConfigToMediocreMassiveConfig", () => {
     options: {
       show_volume_step_buttons: true,
       use_volume_up_down_for_step_buttons: false,
+      ui: {
+        footer_icons: {
+          player: "mdi:play-circle",
+          media_browser: "mdi:playlist-music",
+        },
+      },
     },
     size: "large",
     mode: "panel",
@@ -103,6 +109,12 @@ describe("getMultiConfigToMediocreMassiveConfig", () => {
         options: {
           show_volume_step_buttons: true,
           use_volume_up_down_for_step_buttons: false,
+          ui: {
+            footer_icons: {
+              player: "mdi:play-circle",
+              media_browser: "mdi:playlist-music",
+            },
+          },
           use_experimental_lms_media_browser: false,
         },
       })

--- a/src/utils/getMultiConfigToMediocreMassiveConfig.ts
+++ b/src/utils/getMultiConfigToMediocreMassiveConfig.ts
@@ -42,6 +42,15 @@ export const getMultiConfigToMediocreMassiveConfig = (
         config.options?.show_volume_step_buttons ?? false,
       use_volume_up_down_for_step_buttons:
         config.options?.use_volume_up_down_for_step_buttons ?? false,
+      ...(config.options?.ui?.footer_icons
+        ? {
+            ui: {
+              footer_icons: {
+                ...config.options.ui.footer_icons,
+              },
+            },
+          }
+        : {}),
       use_experimental_lms_media_browser:
         config.options?.use_experimental_lms_media_browser ?? false,
     },

--- a/src/utils/getMultiConfigToMediocreMassiveConfig.ts
+++ b/src/utils/getMultiConfigToMediocreMassiveConfig.ts
@@ -8,6 +8,8 @@ export const getMultiConfigToMediocreMassiveConfig = (
   selectedPlayer: MediocreMultiMediaPlayerCardConfig["media_players"][number],
   mode: "panel" | "card" | "in-card" | "popup"
 ): MediocreMassiveMediaPlayerCardConfig => {
+  const footerIcons =
+    config.size === "large" ? config.options?.ui?.footer_icons : undefined;
   const speaker_group = {
     entity_id: selectedPlayer.speaker_group_entity_id,
     entities: config.media_players
@@ -30,6 +32,8 @@ export const getMultiConfigToMediocreMassiveConfig = (
     use_art_colors: config.use_art_colors,
     action: selectedPlayer.action,
     ma_entity_id: selectedPlayer.ma_entity_id,
+    ma_favorite_button_entity_id: selectedPlayer.ma_favorite_button_entity_id,
+    ma_favorite_control: selectedPlayer.ma_favorite_control,
     lms_entity_id: selectedPlayer.lms_entity_id,
     search: selectedPlayer.search,
     media_browser: selectedPlayer.media_browser,
@@ -42,11 +46,11 @@ export const getMultiConfigToMediocreMassiveConfig = (
         config.options?.show_volume_step_buttons ?? false,
       use_volume_up_down_for_step_buttons:
         config.options?.use_volume_up_down_for_step_buttons ?? false,
-      ...(config.options?.ui?.footer_icons
+      ...(footerIcons
         ? {
             ui: {
               footer_icons: {
-                ...config.options.ui.footer_icons,
+                ...footerIcons,
               },
             },
           }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -21,6 +21,7 @@ export * from "./getMediaPlayerTitleAndSubtitle";
 export * from "./getMediocreLegacyConfigToMultiConfig";
 export * from "./getMultiConfigToMediocreMassiveConfig";
 export * from "./getSearchEntryArray";
+export * from "./linkedVolumePanel";
 export * from "./getSourceIcon";
 export * from "./getVolumeIcon";
 export * from "./selectActiveMultiMediaPlayer";

--- a/src/utils/linkedVolumePanel.test.ts
+++ b/src/utils/linkedVolumePanel.test.ts
@@ -1,0 +1,197 @@
+import type { MediaPlayerEntity, MediocreMultiMediaPlayer } from "@types";
+import {
+  getCanOpenLinkedVolumePanel,
+  getCleanLinkedVolumePanel,
+  getConfiguredLinkedVolumePanelEntities,
+  getLinkedVolumePanelSections,
+} from "./linkedVolumePanel";
+
+const createPlayer = (
+  overrides: Partial<MediocreMultiMediaPlayer> = {}
+): MediocreMultiMediaPlayer => ({
+  entity_id: "media_player.living_room",
+  ...overrides,
+});
+
+const createState = (groupMembers?: string[]) =>
+  ({
+    entity_id: "media_player.test",
+    state: "playing",
+    attributes: {
+      group_members: groupMembers,
+    },
+  }) as MediaPlayerEntity;
+
+describe("linkedVolumePanel", () => {
+  it("cleans and trims configured entities", () => {
+    expect(
+      getCleanLinkedVolumePanel({
+        launch_from: "trailing_volume_bar_button",
+        include_grouped_players: true,
+        entities: [
+          {
+            entity_id: " media_player.living_room ",
+            name: " Living Room ",
+            icon: " mdi:speaker ",
+            show_power: true,
+          },
+        ],
+      })
+    ).toEqual({
+      launch_from: "trailing_volume_bar_button",
+      include_grouped_players: true,
+      entities: [
+        {
+          entity_id: "media_player.living_room",
+          name: "Living Room",
+          icon: "mdi:speaker",
+          show_power: true,
+        },
+      ],
+    });
+  });
+
+  it("returns undefined when panel config is effectively empty", () => {
+    expect(
+      getCleanLinkedVolumePanel({
+        launch_from: "disabled",
+        entities: [],
+      })
+    ).toBeUndefined();
+  });
+
+  it("only exposes unique configured entities", () => {
+    const player = createPlayer({
+      linked_volume_panel: {
+        entities: [
+          { entity_id: "media_player.one" },
+          { entity_id: "media_player.one" },
+          { entity_id: "media_player.two" },
+        ],
+      },
+    });
+
+    expect(getConfiguredLinkedVolumePanelEntities(player)).toEqual([
+      { entity_id: "media_player.one" },
+      { entity_id: "media_player.two" },
+    ]);
+  });
+
+  it("does not open when launch_from is disabled", () => {
+    const player = createPlayer({
+      linked_volume_panel: {
+        entities: [{ entity_id: "media_player.living_room" }],
+      },
+    });
+
+    expect(getCanOpenLinkedVolumePanel(player, [player], {})).toBe(false);
+  });
+
+  it("opens when trailing button is enabled and configured entities exist", () => {
+    const player = createPlayer({
+      linked_volume_panel: {
+        launch_from: "trailing_volume_bar_button",
+        entities: [{ entity_id: "media_player.living_room" }],
+      },
+    });
+
+    expect(getCanOpenLinkedVolumePanel(player, [player], {})).toBe(true);
+  });
+
+  it("groups linked volume entities by player sections", () => {
+    const selectedPlayer = createPlayer({
+      entity_id: "media_player.living_room",
+      speaker_group_entity_id: "media_player.living_room_group",
+      linked_volume_panel: {
+        launch_from: "trailing_volume_bar_button",
+        include_grouped_players: true,
+        entities: [
+          { entity_id: "media_player.living_room" },
+          { entity_id: "media_player.receiver" },
+        ],
+      },
+    });
+    const kitchenPlayer = createPlayer({
+      entity_id: "media_player.kitchen",
+      speaker_group_entity_id: "media_player.kitchen_group",
+      name: "Kitchen",
+    });
+    const officePlayer = createPlayer({
+      entity_id: "media_player.office",
+      speaker_group_entity_id: "media_player.office_group",
+    });
+
+    expect(
+      getLinkedVolumePanelSections(
+        selectedPlayer,
+        [selectedPlayer, kitchenPlayer, officePlayer],
+        {
+          "media_player.living_room_group": createState([
+            "media_player.living_room_group",
+            "media_player.office_group",
+            "media_player.kitchen_group",
+          ]),
+        }
+      )
+    ).toEqual([
+      {
+        key: "media_player.living_room",
+        title: "media_player.living_room",
+        entities: [
+          { entity_id: "media_player.living_room" },
+          { entity_id: "media_player.receiver" },
+        ],
+      },
+      {
+        key: "media_player.office",
+        title: "media_player.office",
+        entities: [{ entity_id: "media_player.office" }],
+      },
+      {
+        key: "media_player.kitchen",
+        title: "media_player.kitchen",
+        entities: [{ entity_id: "media_player.kitchen" }],
+      },
+    ]);
+  });
+
+  it("does not duplicate grouped player self rows when explicitly configured", () => {
+    const selectedPlayer = createPlayer({
+      entity_id: "media_player.living_room",
+      speaker_group_entity_id: "media_player.living_room_group",
+      linked_volume_panel: {
+        launch_from: "trailing_volume_bar_button",
+        include_grouped_players: true,
+        entities: [{ entity_id: "media_player.kitchen", show_power: true }],
+      },
+    });
+    const kitchenPlayer = createPlayer({
+      entity_id: "media_player.kitchen",
+      speaker_group_entity_id: "media_player.kitchen_group",
+      name: "Kitchen",
+      linked_volume_panel: {
+        entities: [{ entity_id: "media_player.kitchen", show_power: true }],
+      },
+    });
+
+    expect(
+      getLinkedVolumePanelSections(selectedPlayer, [selectedPlayer, kitchenPlayer], {
+        "media_player.living_room_group": createState([
+          "media_player.living_room_group",
+          "media_player.kitchen_group",
+        ]),
+      })
+    ).toEqual([
+      {
+        key: "media_player.living_room",
+        title: "media_player.living_room",
+        entities: [{ entity_id: "media_player.kitchen", show_power: true }],
+      },
+      {
+        key: "media_player.kitchen",
+        title: "media_player.kitchen",
+        entities: [{ entity_id: "media_player.kitchen", show_power: true }],
+      },
+    ]);
+  });
+});

--- a/src/utils/linkedVolumePanel.ts
+++ b/src/utils/linkedVolumePanel.ts
@@ -1,0 +1,186 @@
+import type {
+  LinkedVolumePanel,
+  LinkedVolumePanelEntity,
+  MediocreMultiMediaPlayer,
+} from "@types";
+
+type MediaPlayerStateMap = Record<
+  string,
+  {
+    attributes?: unknown;
+  } | undefined
+>;
+
+const getMainEntityId = (player: MediocreMultiMediaPlayer) =>
+  player.speaker_group_entity_id ?? player.entity_id;
+
+const getGroupMembers = (
+  player: MediocreMultiMediaPlayer,
+  states: MediaPlayerStateMap
+) => {
+  const groupMembers = (
+    states[getMainEntityId(player)]?.attributes as
+      | { group_members?: unknown }
+      | undefined
+  )?.group_members;
+  return Array.isArray(groupMembers)
+    ? groupMembers.filter((member): member is string => typeof member === "string")
+    : [];
+};
+
+export const getCleanLinkedVolumePanel = (
+  linkedVolumePanel?: LinkedVolumePanel | null
+): LinkedVolumePanel | undefined => {
+  if (!linkedVolumePanel) return undefined;
+
+  const entities = linkedVolumePanel.entities
+    .map(entity => {
+      const entityId = entity.entity_id?.trim();
+      if (!entityId) return null;
+
+      const name = entity.name?.trim();
+      const icon = entity.icon?.trim();
+
+      return {
+        entity_id: entityId,
+        ...(name ? { name } : {}),
+        ...(icon ? { icon } : {}),
+        ...(entity.show_power ? { show_power: true } : {}),
+      };
+    })
+    .filter(Boolean) as LinkedVolumePanelEntity[];
+
+  const launchFrom =
+    linkedVolumePanel.launch_from === "trailing_volume_bar_button"
+      ? "trailing_volume_bar_button"
+      : "disabled";
+  const includeGroupedPlayers =
+    linkedVolumePanel.include_grouped_players === true;
+
+  if (
+    entities.length === 0 &&
+    !includeGroupedPlayers &&
+    launchFrom === "disabled"
+  ) {
+    return undefined;
+  }
+
+  return {
+    ...(launchFrom === "trailing_volume_bar_button"
+      ? { launch_from: "trailing_volume_bar_button" as const }
+      : {}),
+    ...(includeGroupedPlayers ? { include_grouped_players: true } : {}),
+    entities,
+  };
+};
+
+export const getConfiguredLinkedVolumePanelEntities = (
+  player: MediocreMultiMediaPlayer
+) => {
+  const configuredEntities = player.linked_volume_panel?.entities ?? [];
+  const seen = new Set<string>();
+
+  return configuredEntities.filter(entity => {
+    if (seen.has(entity.entity_id)) return false;
+    seen.add(entity.entity_id);
+    return true;
+  });
+};
+
+const getPlayerTitle = (player: MediocreMultiMediaPlayer) => player.entity_id;
+
+const getSectionEntities = (
+  player: MediocreMultiMediaPlayer,
+  includeSelfByDefault: boolean
+) => {
+  const configuredEntities = getConfiguredLinkedVolumePanelEntities(player);
+
+  if (!includeSelfByDefault) {
+    return configuredEntities;
+  }
+
+  const seen = new Set<string>();
+  const entities: LinkedVolumePanelEntity[] = [];
+  const pushEntity = (entity: LinkedVolumePanelEntity) => {
+    if (seen.has(entity.entity_id)) return;
+    seen.add(entity.entity_id);
+    entities.push(entity);
+  };
+
+  const configuredSelfEntity = configuredEntities.find(
+    entity => entity.entity_id === player.entity_id
+  );
+
+  pushEntity(
+    configuredSelfEntity ?? {
+      entity_id: player.entity_id,
+    }
+  );
+
+  configuredEntities.forEach(pushEntity);
+
+  return entities;
+};
+
+export const getLinkedVolumePanelSections = (
+  selectedPlayer: MediocreMultiMediaPlayer,
+  mediaPlayers: MediocreMultiMediaPlayer[],
+  states: MediaPlayerStateMap
+) => {
+  const sections: {
+    key: string;
+    title: string;
+    entities: LinkedVolumePanelEntity[];
+  }[] = [];
+
+  const selectedEntities = getSectionEntities(selectedPlayer, false);
+  if (selectedEntities.length > 0) {
+    sections.push({
+      key: selectedPlayer.entity_id,
+      title: getPlayerTitle(selectedPlayer),
+      entities: selectedEntities,
+    });
+  }
+
+  if (selectedPlayer.linked_volume_panel?.include_grouped_players !== true) {
+    return sections;
+  }
+
+  const selectedMainEntityId = getMainEntityId(selectedPlayer);
+  const playersByRuntimeId = new Map<string, MediocreMultiMediaPlayer>();
+
+  mediaPlayers.forEach(player => {
+    playersByRuntimeId.set(getMainEntityId(player), player);
+  });
+  playersByRuntimeId.set(selectedMainEntityId, selectedPlayer);
+
+  getGroupMembers(selectedPlayer, states)
+    .filter(entityId => entityId !== selectedMainEntityId)
+    .map(entityId => playersByRuntimeId.get(entityId))
+    .filter(Boolean)
+    .forEach(player => {
+      const groupedPlayer = player!;
+      const entities = getSectionEntities(groupedPlayer, true);
+      if (entities.length === 0) return;
+
+      sections.push({
+        key: groupedPlayer.entity_id,
+        title: getPlayerTitle(groupedPlayer),
+        entities,
+      });
+    });
+
+  return sections;
+};
+
+export const getCanOpenLinkedVolumePanel = (
+  player: MediocreMultiMediaPlayer,
+  mediaPlayers: MediocreMultiMediaPlayer[],
+  states: MediaPlayerStateMap
+) => {
+  if (player.linked_volume_panel?.launch_from !== "trailing_volume_bar_button") {
+    return false;
+  }
+
+  return getLinkedVolumePanelSections(player, mediaPlayers, states).length > 0;
+};

--- a/src/utils/maFavoriteArtwork.config.test.ts
+++ b/src/utils/maFavoriteArtwork.config.test.ts
@@ -1,0 +1,136 @@
+import {
+  getDefaultValuesFromMassiveConfig,
+  getSimpleConfigFromMassiveFormValues,
+} from "@utils/cardConfigUtils";
+import { getMediocreLegacyConfigToMediocreMultiConfig } from "./getMediocreLegacyConfigToMultiConfig";
+import { getMediocreMassiveLegacyConfigToMediocreMultiConfig } from "./getMediocreMassiveLegacyConfigToMultiConfig";
+import { getMultiConfigToMediocreMassiveConfig } from "./getMultiConfigToMediocreMassiveConfig";
+import type {
+  MediocreMassiveMediaPlayerCardConfig,
+  MediocreMediaPlayerCardConfig,
+  MediocreMultiMediaPlayerCardConfig,
+} from "@types";
+
+describe("maFavoriteArtwork config plumbing", () => {
+  it("preserves MA favorite artwork fields in massive config defaults and cleanup", () => {
+    const config: MediocreMassiveMediaPlayerCardConfig = {
+      type: "custom:mediocre-massive-media-player-card",
+      entity_id: "media_player.test",
+      mode: "card",
+      ma_favorite_control: {
+        show_on_artwork: true,
+        favorite_button_size: "medium",
+        favorite_button_offset: "18px 24px",
+        active_color: "#ffd54f",
+        inactive_color: "#101010",
+      },
+    };
+
+    expect(getDefaultValuesFromMassiveConfig(config)).toEqual(
+      expect.objectContaining({
+        ma_favorite_control: {
+          show_on_artwork: true,
+          favorite_button_size: "medium",
+          favorite_button_offset: "18px 24px",
+          active_color: "#ffd54f",
+          inactive_color: "#101010",
+        },
+      })
+    );
+
+    expect(getSimpleConfigFromMassiveFormValues(config)).toEqual(
+      expect.objectContaining({
+        mode: "card",
+        ma_favorite_control: {
+          show_on_artwork: true,
+          favorite_button_size: "medium",
+          favorite_button_offset: "18px 24px",
+          active_color: "#ffd54f",
+          inactive_color: "#101010",
+        },
+      })
+    );
+  });
+
+  it("moves MA favorite artwork config from legacy regular card config to the first multi player", () => {
+    const config: MediocreMediaPlayerCardConfig = {
+      type: "custom:mediocre-media-player-card",
+      entity_id: "media_player.living_room",
+      ma_entity_id: "media_player.ma_living_room",
+      ma_favorite_button_entity_id: "button.favorite_current_song",
+      ma_favorite_control: {
+        show_on_artwork: true,
+        favorite_button_size: "medium",
+      },
+    };
+
+    const result = getMediocreLegacyConfigToMediocreMultiConfig(config);
+
+    expect(result.media_players[0].ma_favorite_control).toEqual({
+      show_on_artwork: true,
+      favorite_button_size: "medium",
+    });
+    expect(result.media_players[0].ma_favorite_button_entity_id).toBe(
+      "button.favorite_current_song"
+    );
+  });
+
+  it("moves MA favorite artwork config from legacy massive card config to the first multi player", () => {
+    const config: MediocreMassiveMediaPlayerCardConfig = {
+      type: "custom:mediocre-massive-media-player-card",
+      entity_id: "media_player.living_room",
+      mode: "card",
+      ma_entity_id: "media_player.ma_living_room",
+      ma_favorite_button_entity_id: "button.favorite_current_song",
+      ma_favorite_control: {
+        show_on_artwork: true,
+        favorite_button_offset: "22px 18px",
+      },
+    };
+
+    const result = getMediocreMassiveLegacyConfigToMediocreMultiConfig(config);
+
+    expect(result.media_players[0].ma_favorite_control).toEqual({
+      show_on_artwork: true,
+      favorite_button_offset: "22px 18px",
+    });
+    expect(result.media_players[0].ma_favorite_button_entity_id).toBe(
+      "button.favorite_current_song"
+    );
+  });
+
+  it("passes MA favorite artwork config from multi-card config to the derived massive config", () => {
+    const config: MediocreMultiMediaPlayerCardConfig = {
+      type: "custom:mediocre-multi-media-player-card",
+      entity_id: "media_player.living_room",
+      size: "large",
+      mode: "panel",
+      media_players: [
+        {
+          entity_id: "media_player.living_room",
+          can_be_grouped: true,
+          ma_entity_id: "media_player.ma_living_room",
+          ma_favorite_button_entity_id: "button.favorite_current_song",
+          ma_favorite_control: {
+            show_on_artwork: true,
+            favorite_button_offset: "20px 12px",
+          },
+        },
+      ],
+    };
+
+    const result = getMultiConfigToMediocreMassiveConfig(
+      config,
+      config.media_players[0],
+      "panel"
+    );
+
+    expect(result.ma_favorite_control).toEqual({
+      show_on_artwork: true,
+      favorite_button_offset: "20px 12px",
+    });
+    expect(result.ma_favorite_button_entity_id).toBe(
+      "button.favorite_current_song"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds a configurable `Linked Volume Panel` to the large multi-player card.

It is designed for setups where one selected player is logically tied to one or more other volume-controlled endpoints, for example:

- a Sonos player that also feeds an AVR
- a player plus one or more zones with their own volume controls

This PR adds:

- a per-player `linked_volume_panel` config block
- a new `Volume Panel` view in the large multi-player card
- per-player control over launching that panel from the trailing volume-bar button
- optional inclusion of grouped players at runtime
- a UI customization override for the trailing volume button icon

This PR is intentionally limited to the large multi-player card.

## Why

Many users have linked Volume entities. Other than adding uggly real-estate consuming additional volume bars below the media card, there was no first class way of dealing with this scenario.

In practice, this feature needs to answer three questions together:

- which endpoints should appear in the panel
- whether grouped players should also be included at runtime
- how the user opens the panel

This PR moves the activation point into the per-player panel config so the feature reads as one coherent block. It is attached, obviously, to each media player.

## Config

<img width="896" height="1050" alt="image" src="https://github.com/user-attachments/assets/2352be5d-bb1f-484e-8d9f-6e10c415e882" />


### Per-player

```yaml
linked_volume_panel:
  launch_from: trailing_volume_bar_button
  include_grouped_players: true
  entities:
    - entity_id: media_player.ma_basement_sonos
      name: MA Basement Sonos
    - entity_id: media_player.family_pioneer
      name: Family Pioneer
      show_power: true
```

### Important rule:

- if you want the selected player itself to appear in the panel, add it explicitly to entities

###UI customization
The icon override is in UI customization:
<img width="988" height="702" alt="image" src="https://github.com/user-attachments/assets/1efd3870-67a3-4d7d-a60c-a8f949579455" />

```yaml
options:
  ui:
    volume_bar:
      trailing_volume_button_icon: mdi:volume-source
```

###

<img width="988" height="178" alt="image" src="https://github.com/user-attachments/assets/8e8137f7-95da-408e-a9c6-4e8a8375e008" />

<img width="956" height="1544" alt="image" src="https://github.com/user-attachments/assets/1cae1c1c-fb92-4603-9a37-114389f2500b" />

