### PR TITLE
fix: fall back to media_play/media_stop for players without pause support

### DIFF
--- a/src/components/MassivePlaybackController/components/PlaybackControls.tsx
+++ b/src/components/MassivePlaybackController/components/PlaybackControls.tsx
@@ -30,6 +30,7 @@ export const PlaybackControls = () => {
     supportsShuffle,
     supportsRepeat,
     supportsTogglePlayPause,
+    supportsPause,
     supportsStop,
   } = useSupportedFeatures();
 
@@ -62,7 +63,13 @@ export const PlaybackControls = () => {
         <IconButton
           size="x-large"
           onClick={togglePlayback}
-          icon={playing ? "mdi:pause-circle" : "mdi:play-circle"}
+          icon={
+            playing
+              ? supportsPause
+                ? "mdi:pause-circle"
+                : "mdi:stop-circle"
+              : "mdi:play-circle"
+          }
         />
       ) : supportsStop ? (
         <IconButton size="x-large" onClick={stop} icon={"mdi:stop"} />

--- a/src/components/MediocreCompactMultiMediaPlayerCard/components/PlaybackControls.tsx
+++ b/src/components/MediocreCompactMultiMediaPlayerCard/components/PlaybackControls.tsx
@@ -42,6 +42,7 @@ export const PlaybackControls = () => {
     supportsShuffle,
     supportsRepeat,
     supportsTogglePlayPause,
+    supportsPause,
     supportsStop,
   } = useSupportedFeatures();
 
@@ -81,7 +82,13 @@ export const PlaybackControls = () => {
           id="mmpc-compact-play-pause-toggle"
           size="medium"
           onClick={togglePlayback}
-          icon={playing ? "mdi:pause-circle" : "mdi:play-circle"}
+          icon={
+            playing
+              ? supportsPause
+                ? "mdi:pause-circle"
+                : "mdi:stop-circle"
+              : "mdi:play-circle"
+          }
         />
       ) : supportsStop ? (
         <IconButton

--- a/src/components/MediocreCompactMultiMediaPlayerCard/components/SpeakerGrouping.tsx
+++ b/src/components/MediocreCompactMultiMediaPlayerCard/components/SpeakerGrouping.tsx
@@ -20,7 +20,7 @@ import { css } from "@emotion/react";
 import { theme } from "@constants";
 import { useIntl } from "@components/i18n";
 import { useSelectedPlayer } from "@components/SelectedPlayerContext";
-import { getHass } from "@utils";
+import { getHass, getSupportedFeatures } from "@utils";
 
 const styles = {
   speakerGroupContainer: css({
@@ -155,9 +155,10 @@ export const SpeakerGrouping = () => {
     return (
       <PlayerContextProvider key={player.entity_id} entityId={player.entity_id}>
         {({ player: { state } }) => {
-          const supportedFeatures = player.attributes?.supported_features;
-          const supportsPause =
-            supportedFeatures !== undefined && (supportedFeatures & 1) === 1;
+          const { supportsPause, supportsStop } = getSupportedFeatures(
+            state,
+            player.attributes ?? {}
+          );
           return (
             <Chip
               css={[
@@ -184,14 +185,13 @@ export const SpeakerGrouping = () => {
 
                     e.preventDefault();
 
-                    if (supportsPause || supportedFeatures === undefined) {
+                    if (supportsPause) {
                       getHass().callService(
                         "media_player",
                         "media_play_pause",
                         { entity_id: player.entity_id }
                       );
                     } else if (state === "playing") {
-                      const supportsStop = (supportedFeatures & 4096) === 4096;
                       getHass().callService(
                         "media_player",
                         supportsStop ? "media_stop" : "media_pause",

--- a/src/components/MediocreCompactMultiMediaPlayerCard/components/SpeakerGrouping.tsx
+++ b/src/components/MediocreCompactMultiMediaPlayerCard/components/SpeakerGrouping.tsx
@@ -155,6 +155,9 @@ export const SpeakerGrouping = () => {
     return (
       <PlayerContextProvider key={player.entity_id} entityId={player.entity_id}>
         {({ player: { state } }) => {
+          const supportedFeatures = player.attributes?.supported_features;
+          const supportsPause =
+            supportedFeatures !== undefined && (supportedFeatures & 1) === 1;
           return (
             <Chip
               css={[
@@ -181,11 +184,6 @@ export const SpeakerGrouping = () => {
 
                     e.preventDefault();
 
-                    const supportedFeatures =
-                      player.attributes?.supported_features;
-                    const supportsPause =
-                      supportedFeatures !== undefined &&
-                      (supportedFeatures & 1) === 1;
                     if (supportsPause || supportedFeatures === undefined) {
                       getHass().callService(
                         "media_player",
@@ -207,7 +205,9 @@ export const SpeakerGrouping = () => {
                   }}
                   icon={
                     state === "playing"
-                      ? "mdi:pause-circle-outline"
+                      ? supportsPause
+                        ? "mdi:pause-circle-outline"
+                        : "mdi:stop-circle-outline"
                       : "mdi:play-circle-outline"
                   }
                 />

--- a/src/components/MediocreCompactMultiMediaPlayerCard/components/SpeakerGrouping.tsx
+++ b/src/components/MediocreCompactMultiMediaPlayerCard/components/SpeakerGrouping.tsx
@@ -181,15 +181,29 @@ export const SpeakerGrouping = () => {
 
                     e.preventDefault();
 
-                    getHass().callService(
-                      "media_player",
-
-                      "media_play_pause",
-
-                      {
+                    const supportedFeatures =
+                      player.attributes?.supported_features;
+                    const supportsPause =
+                      supportedFeatures !== undefined &&
+                      (supportedFeatures & 1) === 1;
+                    if (supportsPause || supportedFeatures === undefined) {
+                      getHass().callService(
+                        "media_player",
+                        "media_play_pause",
+                        { entity_id: player.entity_id }
+                      );
+                    } else if (state === "playing") {
+                      const supportsStop = (supportedFeatures & 4096) === 4096;
+                      getHass().callService(
+                        "media_player",
+                        supportsStop ? "media_stop" : "media_pause",
+                        { entity_id: player.entity_id }
+                      );
+                    } else {
+                      getHass().callService("media_player", "media_play", {
                         entity_id: player.entity_id,
-                      }
-                    );
+                      });
+                    }
                   }}
                   icon={
                     state === "playing"

--- a/src/hooks/usePlayerActions.tsx
+++ b/src/hooks/usePlayerActions.tsx
@@ -1,13 +1,16 @@
 import { usePlayer } from "@components";
 import { getHass } from "@utils";
+import { useSupportedFeatures } from "@hooks/useSupportedFeatures";
 import { useCallback, useMemo } from "preact/hooks";
 
 export const usePlayerActions = () => {
   const {
     entity_id,
     state,
-    attributes: { shuffle, repeat, supported_features: supportedFeatures },
+    attributes: { shuffle, repeat },
   } = usePlayer();
+
+  const { supportsPause, supportsStop } = useSupportedFeatures();
 
   const stop = useCallback(() => {
     getHass().callService("media_player", "media_stop", {
@@ -16,12 +19,9 @@ export const usePlayerActions = () => {
   }, [entity_id]);
 
   const togglePlayback = useCallback(() => {
-    const supportsPause =
-      supportedFeatures !== undefined && (supportedFeatures & 1) === 1;
-    if (supportsPause || supportedFeatures === undefined) {
+    if (supportsPause) {
       getHass().callService("media_player", "media_play_pause", { entity_id });
     } else if (state === "playing") {
-      const supportsStop = (supportedFeatures & 4096) === 4096;
       getHass().callService(
         "media_player",
         supportsStop ? "media_stop" : "media_pause",
@@ -30,7 +30,7 @@ export const usePlayerActions = () => {
     } else {
       getHass().callService("media_player", "media_play", { entity_id });
     }
-  }, [entity_id, state, supportedFeatures]);
+  }, [entity_id, state, supportsPause, supportsStop]);
 
   const nextTrack = useCallback(() => {
     getHass().callService("media_player", "media_next_track", {

--- a/src/hooks/usePlayerActions.tsx
+++ b/src/hooks/usePlayerActions.tsx
@@ -5,7 +5,8 @@ import { useCallback, useMemo } from "preact/hooks";
 export const usePlayerActions = () => {
   const {
     entity_id,
-    attributes: { shuffle, repeat },
+    state,
+    attributes: { shuffle, repeat, supported_features: supportedFeatures },
   } = usePlayer();
 
   const stop = useCallback(() => {
@@ -15,10 +16,21 @@ export const usePlayerActions = () => {
   }, [entity_id]);
 
   const togglePlayback = useCallback(() => {
-    getHass().callService("media_player", "media_play_pause", {
-      entity_id,
-    });
-  }, [entity_id]);
+    const supportsPause =
+      supportedFeatures !== undefined && (supportedFeatures & 1) === 1;
+    if (supportsPause || supportedFeatures === undefined) {
+      getHass().callService("media_player", "media_play_pause", { entity_id });
+    } else if (state === "playing") {
+      const supportsStop = (supportedFeatures & 4096) === 4096;
+      getHass().callService(
+        "media_player",
+        supportsStop ? "media_stop" : "media_pause",
+        { entity_id }
+      );
+    } else {
+      getHass().callService("media_player", "media_play", { entity_id });
+    }
+  }, [entity_id, state, supportedFeatures]);
 
   const nextTrack = useCallback(() => {
     getHass().callService("media_player", "media_next_track", {

--- a/src/hooks/useSupportedFeatures.test.ts
+++ b/src/hooks/useSupportedFeatures.test.ts
@@ -119,11 +119,18 @@ describe("getSupportedFeatures", () => {
         supported_features: 32768 | 4096, // SUPPORT_SHUFFLE_SET | SUPPORT_STOP
       });
       expect(result.supportsShuffle).toBe(true);
-      // supportsTogglePlayPause true
+      // supportsTogglePlayPause true (PAUSE bit)
       result = getSupportedFeatures("playing", {
         ...baseAttributes,
         shuffle: false,
-        supported_features: 32768 | 16384, // SUPPORT_SHUFFLE_SET | SUPPORT_PAUSE
+        supported_features: 32768 | 1, // SUPPORT_SHUFFLE_SET | SUPPORT_PAUSE
+      });
+      expect(result.supportsShuffle).toBe(true);
+      // supportsTogglePlayPause true (PLAY+STOP)
+      result = getSupportedFeatures("playing", {
+        ...baseAttributes,
+        shuffle: false,
+        supported_features: 32768 | 16384 | 4096, // SUPPORT_SHUFFLE_SET | SUPPORT_PLAY | SUPPORT_STOP
       });
       expect(result.supportsShuffle).toBe(true);
     });
@@ -183,11 +190,18 @@ describe("getSupportedFeatures", () => {
         supported_features: 262144 | 4096, // SUPPORT_REPEAT_SET | SUPPORT_STOP
       });
       expect(result.supportsRepeat).toBe(true);
-      // supportsTogglePlayPause true
+      // supportsTogglePlayPause true (PAUSE bit)
       result = getSupportedFeatures("playing", {
         ...baseAttributes,
         repeat: "off",
-        supported_features: 262144 | 16384, // SUPPORT_REPEAT_SET | SUPPORT_PAUSE
+        supported_features: 262144 | 1, // SUPPORT_REPEAT_SET | SUPPORT_PAUSE
+      });
+      expect(result.supportsRepeat).toBe(true);
+      // supportsTogglePlayPause true (PLAY+STOP)
+      result = getSupportedFeatures("playing", {
+        ...baseAttributes,
+        repeat: "off",
+        supported_features: 262144 | 16384 | 4096, // SUPPORT_REPEAT_SET | SUPPORT_PLAY | SUPPORT_STOP
       });
       expect(result.supportsRepeat).toBe(true);
     });
@@ -261,9 +275,25 @@ describe("getSupportedFeatures", () => {
     it("should return true when player is not off and has pause feature", () => {
       const result = getSupportedFeatures("playing", {
         ...baseAttributes,
-        supported_features: 16384, // SUPPORT_PAUSE
+        supported_features: 1, // SUPPORT_PAUSE
       });
       expect(result.supportsTogglePlayPause).toBe(true);
+    });
+
+    it("should return true when player has play+stop features", () => {
+      const result = getSupportedFeatures("playing", {
+        ...baseAttributes,
+        supported_features: 16384 | 4096, // SUPPORT_PLAY | SUPPORT_STOP
+      });
+      expect(result.supportsTogglePlayPause).toBe(true);
+    });
+
+    it("should return false when player has play but not pause or stop", () => {
+      const result = getSupportedFeatures("playing", {
+        ...baseAttributes,
+        supported_features: 16384, // SUPPORT_PLAY only
+      });
+      expect(result.supportsTogglePlayPause).toBe(false);
     });
 
     it("should return false when player is off", () => {
@@ -308,11 +338,18 @@ describe("getSupportedFeatures", () => {
           supported_features: 32768 | 4096,
         }).supportsShuffle
       ).toBe(true);
-      // Shuffle + togglePlayPause
+      // Shuffle + togglePlayPause (PAUSE bit)
       expect(
         getSupportedFeatures("playing", {
           ...shuffleAttrs,
-          supported_features: 32768 | 16384,
+          supported_features: 32768 | 1,
+        }).supportsShuffle
+      ).toBe(true);
+      // Shuffle + togglePlayPause (PLAY+STOP)
+      expect(
+        getSupportedFeatures("playing", {
+          ...shuffleAttrs,
+          supported_features: 32768 | 16384 | 4096,
         }).supportsShuffle
       ).toBe(true);
     });
@@ -333,11 +370,18 @@ describe("getSupportedFeatures", () => {
           supported_features: 262144 | 4096,
         }).supportsRepeat
       ).toBe(true);
-      // Repeat + togglePlayPause
+      // Repeat + togglePlayPause (PAUSE bit)
       expect(
         getSupportedFeatures("playing", {
           ...repeatAttrs,
-          supported_features: 262144 | 16384,
+          supported_features: 262144 | 1,
+        }).supportsRepeat
+      ).toBe(true);
+      // Repeat + togglePlayPause (PLAY+STOP)
+      expect(
+        getSupportedFeatures("playing", {
+          ...repeatAttrs,
+          supported_features: 262144 | 16384 | 4096,
         }).supportsRepeat
       ).toBe(true);
     });

--- a/src/hooks/useSupportedFeatures.tsx
+++ b/src/hooks/useSupportedFeatures.tsx
@@ -17,6 +17,7 @@ export function useSupportedFeatures() {
       supportedFeatures.supportsShuffle,
       supportedFeatures.supportsRepeat,
       supportedFeatures.supportsTogglePlayPause,
+      supportedFeatures.supportsPause,
       supportedFeatures.supportsStop,
     ]
   );

--- a/src/utils/supportedFeaturesUtils.test.ts
+++ b/src/utils/supportedFeaturesUtils.test.ts
@@ -86,6 +86,34 @@ describe("getSupportedFeatures", () => {
       });
       expect(result.supportsTogglePlayPause).toBe(false);
     });
+
+    it("supportsPause is true only when PAUSE bit is set", () => {
+      const withPause = getSupportedFeatures("playing", {
+        supported_features: FEATURE_PAUSE,
+      });
+      expect(withPause.supportsPause).toBe(true);
+
+      const playOnly = getSupportedFeatures("playing", {
+        supported_features: FEATURE_PLAY,
+      });
+      expect(playOnly.supportsPause).toBe(false);
+    });
+
+    it("supportsPause is false when player is off", () => {
+      const result = getSupportedFeatures("off", {
+        supported_features: FEATURE_PAUSE,
+      });
+      expect(result.supportsPause).toBe(false);
+    });
+
+    it("HEOS-like player (PLAY+STOP, no PAUSE) has supportsTogglePlayPause true but supportsPause false", () => {
+      const result = getSupportedFeatures("playing", {
+        supported_features: FEATURE_PLAY | FEATURE_STOP,
+      });
+      expect(result.supportsTogglePlayPause).toBe(true);
+      expect(result.supportsPause).toBe(false);
+      expect(result.supportsStop).toBe(true);
+    });
   });
 
   describe("stop", () => {

--- a/src/utils/supportedFeaturesUtils.test.ts
+++ b/src/utils/supportedFeaturesUtils.test.ts
@@ -73,11 +73,18 @@ describe("getSupportedFeatures", () => {
       expect(result.supportsTogglePlayPause).toBe(true);
     });
 
-    it("supports toggle play/pause via PLAY bit (16384)", () => {
+    it("supports toggle play/pause via PLAY+STOP bits", () => {
+      const result = getSupportedFeatures("playing", {
+        supported_features: FEATURE_PLAY | FEATURE_STOP,
+      });
+      expect(result.supportsTogglePlayPause).toBe(true);
+    });
+
+    it("does not support toggle play/pause when PLAY is set but not PAUSE or STOP", () => {
       const result = getSupportedFeatures("playing", {
         supported_features: FEATURE_PLAY,
       });
-      expect(result.supportsTogglePlayPause).toBe(true);
+      expect(result.supportsTogglePlayPause).toBe(false);
     });
 
     it("does not support toggle play/pause when neither bit is set", () => {

--- a/src/utils/supportedFeaturesUtils.ts
+++ b/src/utils/supportedFeaturesUtils.ts
@@ -13,6 +13,7 @@ interface SupportedFeatures {
   supportsShuffle: boolean;
   supportsRepeat: boolean;
   supportsTogglePlayPause: boolean;
+  supportsPause: boolean;
   supportsStop: boolean;
 }
 
@@ -35,6 +36,11 @@ export function getSupportedFeatures(
     !isOff &&
     supportedFeatures !== undefined &&
     (supportedFeatures & 32) === 32;
+
+  const supportsPause =
+    !isOff &&
+    supportedFeatures !== undefined &&
+    (supportedFeatures & 1) === 1;
 
   const supportsTogglePlayPause =
     !isOff &&
@@ -69,6 +75,7 @@ export function getSupportedFeatures(
     supportsShuffle,
     supportsRepeat,
     supportsTogglePlayPause,
+    supportsPause,
     supportsStop,
   };
 }

--- a/src/utils/supportedFeaturesUtils.ts
+++ b/src/utils/supportedFeaturesUtils.ts
@@ -38,9 +38,7 @@ export function getSupportedFeatures(
     (supportedFeatures & 32) === 32;
 
   const supportsPause =
-    !isOff &&
-    supportedFeatures !== undefined &&
-    (supportedFeatures & 1) === 1;
+    !isOff && supportedFeatures !== undefined && (supportedFeatures & 1) === 1;
 
   const supportsTogglePlayPause =
     !isOff &&

--- a/src/utils/supportedFeaturesUtils.ts
+++ b/src/utils/supportedFeaturesUtils.ts
@@ -45,7 +45,11 @@ export function getSupportedFeatures(
   const supportsTogglePlayPause =
     !isOff &&
     supportedFeatures !== undefined &&
-    ((supportedFeatures & 1) === 1 || (supportedFeatures & 16384) === 16384);
+    // Either PAUSE is supported (media_play_pause works), or PLAY+STOP are
+    // both supported (can use individual actions without leaving player stuck)
+    ((supportedFeatures & 1) === 1 ||
+      ((supportedFeatures & 16384) === 16384 &&
+        (supportedFeatures & 4096) === 4096));
 
   const supportsStop =
     !isOff &&


### PR DESCRIPTION
Players like HEOS support PLAY and STOP but not PAUSE, so calling
media_play_pause throws an error. Now togglePlayback checks the
supported_features bitmask and uses explicit media_play / media_stop
actions when PAUSE (bit 1) is absent. Same fix applied to the
SpeakerGrouping inline handler.

Fixes #457

https://claude.ai/code/session_01DrPwmGicjtFxt9GLAvEphw