### PR TITLE
Replace custom MassivePopUp overlay with ha-adaptive-dialog

### DIFF
--- a/src/components/MediocreCompactMultiMediaPlayerCard/components/MassivePopUp.tsx
+++ b/src/components/MediocreCompactMultiMediaPlayerCard/components/MassivePopUp.tsx
@@ -1,4 +1,4 @@
-import { useContext, useMemo } from "preact/hooks";
+import { useContext, useEffect, useMemo, useRef } from "preact/hooks";
 import {
   CardContext,
   CardContextType,
@@ -11,97 +11,25 @@ import {
   usePlayer,
   MediocreLargeMultiMediaPlayerCard,
 } from "@components";
-import { css, keyframes } from "@emotion/react";
+import { css } from "@emotion/react";
 import { useActionProps } from "@hooks";
 import { MediocreMultiMediaPlayerCardConfig } from "@types";
-import { getDeviceIcon, isDarkMode } from "@utils";
-import { theme } from "@constants";
+import { getDeviceIcon } from "@utils";
 import { useSelectedPlayer } from "@components/SelectedPlayerContext";
 
-const slideUp = keyframes`
-  from {
-    top: 15%;
-    opacity: 0;
-  }
-  to {
-    top: 0%;
-    opacity: 1;
-  }
-`;
-
-const headerHeight = 58;
-
 const styles = {
-  overlay: css({
-    position: "fixed",
-    top: 0,
-    left: 0,
-    width: "100%",
-    height: "100%",
-    zIndex: 8, // Above header and below dialogs
-    transition: "opacity 0.3s ease-in-out",
+  titleContainer: css({
     display: "flex",
-    justifyContent: "center",
-    alignItems: "flex-end",
-    "@media screen and (min-height: 832px)": {
-      alignItems: "center",
-    },
-  }),
-  clickableBackground: css({
-    position: "absolute",
-    top: 0,
-    left: 0,
-    width: "100%",
-    height: "100%",
-    zIndex: 0,
-  }),
-  popUpContainer: css({
-    position: "relative",
-    animation: `${slideUp} 0.55s cubic-bezier(0.25, 1, 0.5, 1) forwards`,
-    maxHeight: "98vh",
-    height: "fit-content",
-    width: "424px",
-    maxWidth: "98vw",
-    backgroundColor: theme.colors.dialog,
-    overflow: "hidden",
-    "--mmpc-popup-shadow-color": "var(--ha-color-shadow-dark)",
-    boxShadow: "var(--ha-box-shadow-l)",
-    borderTopLeftRadius: "var(--ha-dialog-border-radius, 28px)",
-    borderTopRightRadius: "var(--ha-dialog-border-radius, 28px)",
-    "@media screen and (min-height: 832px)": {
-      borderRadius: "var(--ha-dialog-border-radius, 28px)",
-      boxShadow: "0px 0px 20px var(--mmpc-popup-shadow-color)",
-    },
-  }),
-  popUpContainerLight: css({
-    boxShadow: "0px 10px 20px --mmpc-popup-shadow-color",
-  }),
-  popUpContent: css({
-    display: "grid",
-    height: "100%",
-  }),
-  popUpHeader: css({
-    display: "flex",
-    height: headerHeight,
-    justifyContent: "flex-start",
     alignItems: "center",
-    padding: "0px 16px",
-    borderBottom: "1px solid var(--divider-color, rgba(0, 0, 0, 0.12))",
     gap: "8px",
+    overflow: "hidden",
   }),
   title: css({
-    margin: 0,
-    fontSize: "18px",
-    fontWeight: 500,
-    color: theme.colors.onDialog,
     overflow: "hidden",
     textOverflow: "ellipsis",
     whiteSpace: "nowrap",
-    marginRight: "auto",
   }),
   massiveCard: css({
-    maxHeight: `calc(98vh - ${headerHeight}px)`,
-    maxWidth: "98vw",
     width: "100%",
     height: 754,
     overflow: "hidden",
@@ -171,44 +99,37 @@ export const MassivePopUp = ({
     },
   });
 
-  if (!visible) {
-    return null;
-  }
+  const dialogRef = useRef<HTMLElement>(null);
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    const handleClosed = () => setVisible(false);
+    dialog.addEventListener("closed", handleClosed);
+    return () => dialog.removeEventListener("closed", handleClosed);
+  }, [setVisible]);
 
   return (
-    <div css={styles.overlay}>
-      <div css={styles.clickableBackground} onClick={() => setVisible(false)} />
-      <div
-        css={[
-          styles.popUpContainer,
-          !isDarkMode() && styles.popUpContainerLight,
-        ]}
-      >
-        <div css={styles.popUpHeader}>
-          <Icon size={"small"} icon={mdiIcon} />
-          <h2 css={styles.title}>
-            {friendlyName}
-            {groupMembers?.length > 1 && (
-              <span> +{groupMembers.length - 1}</span>
-            )}
-          </h2>
-          <IconButton
-            size="small"
-            {...moreInfoButtonProps}
-            icon="mdi:dots-vertical"
-          />
-          <IconButton
-            icon="mdi:close"
-            size="small"
-            onClick={() => setVisible(false)}
-          />
-        </div>
-        <div css={styles.popUpContent}>
-          <CardContextProvider rootElement={rootElement} config={cardConfig}>
-            <MediocreLargeMultiMediaPlayerCard css={styles.massiveCard} />
-          </CardContextProvider>
-        </div>
-      </div>
-    </div>
+    <ha-adaptive-dialog ref={dialogRef} open={visible}>
+      <span slot="headerTitle" css={styles.titleContainer}>
+        <Icon size="small" icon={mdiIcon} />
+        <span css={styles.title}>
+          {friendlyName}
+          {groupMembers?.length > 1 && (
+            <span> +{groupMembers.length - 1}</span>
+          )}
+        </span>
+      </span>
+      <span slot="headerActionItems">
+        <IconButton
+          size="small"
+          {...moreInfoButtonProps}
+          icon="mdi:dots-vertical"
+        />
+      </span>
+      <CardContextProvider rootElement={rootElement} config={cardConfig}>
+        <MediocreLargeMultiMediaPlayerCard css={styles.massiveCard} />
+      </CardContextProvider>
+    </ha-adaptive-dialog>
   );
 };

--- a/src/components/MediocreCompactMultiMediaPlayerCard/components/MassivePopUp.tsx
+++ b/src/components/MediocreCompactMultiMediaPlayerCard/components/MassivePopUp.tsx
@@ -110,7 +110,7 @@ export const MassivePopUp = ({
   }, [setVisible]);
 
   return (
-    <ha-adaptive-dialog ref={dialogRef} open={visible}>
+    <ha-adaptive-dialog ref={dialogRef} hass={hass} open={visible}>
       <span slot="headerTitle" css={styles.titleContainer}>
         <Icon size="small" icon={mdiIcon} />
         <span css={styles.title}>

--- a/src/components/MediocreCompactMultiMediaPlayerCard/components/MassivePopUp.tsx
+++ b/src/components/MediocreCompactMultiMediaPlayerCard/components/MassivePopUp.tsx
@@ -31,7 +31,8 @@ const styles = {
   }),
   massiveCard: css({
     width: "100%",
-    height: 754,
+    height: "min-content",
+    minHeight: "100%",
     overflow: "hidden",
   }),
 };
@@ -110,7 +111,7 @@ export const MassivePopUp = ({
   }, [setVisible]);
 
   return (
-    <ha-adaptive-dialog ref={dialogRef} hass={hass} open={visible}>
+    <ha-adaptive-dialog ref={dialogRef} hass={hass} open={visible} flexcontent>
       <span slot="headerTitle" css={styles.titleContainer}>
         <Icon size="small" icon={mdiIcon} />
         <span css={styles.title}>

--- a/src/components/MediocreCompactMultiMediaPlayerCard/components/MassivePopUp.tsx
+++ b/src/components/MediocreCompactMultiMediaPlayerCard/components/MassivePopUp.tsx
@@ -115,9 +115,7 @@ export const MassivePopUp = ({
         <Icon size="small" icon={mdiIcon} />
         <span css={styles.title}>
           {friendlyName}
-          {groupMembers?.length > 1 && (
-            <span> +{groupMembers.length - 1}</span>
-          )}
+          {groupMembers?.length > 1 && <span> +{groupMembers.length - 1}</span>}
         </span>
       </span>
       <span slot="headerActionItems">

--- a/src/types/ha.ts
+++ b/src/types/ha.ts
@@ -85,6 +85,21 @@ interface HaButtonAttributes extends preact.JSX.HTMLAttributes<HTMLElement> {
   onClick?: (e?: preact.JSX.TargetedMouseEvent<HTMLElement>) => void;
 }
 
+interface HaAdaptiveDialogAttributes
+  extends preact.JSX.HTMLAttributes<HTMLElement> {
+  open?: boolean;
+  type?: "alert" | "standard";
+  width?: "small" | "medium" | "large" | "full";
+  "prevent-scrim-close"?: boolean;
+  "allow-mode-change"?: boolean;
+  "without-header"?: boolean;
+  "hide-close-button"?: boolean;
+  "header-title"?: string;
+  "header-subtitle"?: string;
+  "header-subtitle-position"?: "above" | "below";
+  flexcontent?: boolean;
+}
+
 declare module "preact" {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace JSX {
@@ -98,6 +113,7 @@ declare module "preact" {
       "ha-entity-picker": HaEntityPickerAttributes;
       "ha-entities-picker": HaEntitiesPickerAttributes;
       "ha-button": HaButtonAttributes;
+      "ha-adaptive-dialog": HaAdaptiveDialogAttributes;
     }
   }
 }

--- a/src/types/ha.ts
+++ b/src/types/ha.ts
@@ -87,6 +87,7 @@ interface HaButtonAttributes extends preact.JSX.HTMLAttributes<HTMLElement> {
 
 interface HaAdaptiveDialogAttributes extends preact.JSX
   .HTMLAttributes<HTMLElement> {
+  hass?: HomeAssistant;
   open?: boolean;
   type?: "alert" | "standard";
   width?: "small" | "medium" | "large" | "full";

--- a/src/types/ha.ts
+++ b/src/types/ha.ts
@@ -85,8 +85,8 @@ interface HaButtonAttributes extends preact.JSX.HTMLAttributes<HTMLElement> {
   onClick?: (e?: preact.JSX.TargetedMouseEvent<HTMLElement>) => void;
 }
 
-interface HaAdaptiveDialogAttributes
-  extends preact.JSX.HTMLAttributes<HTMLElement> {
+interface HaAdaptiveDialogAttributes extends preact.JSX
+  .HTMLAttributes<HTMLElement> {
   open?: boolean;
   type?: "alert" | "standard";
   width?: "small" | "medium" | "large" | "full";


### PR DESCRIPTION
Swaps the hand-rolled fixed-position overlay (with manual animation,
backdrop, and close button) for the native ha-adaptive-dialog web
component. The dialog automatically adapts to a bottom sheet on small
viewports and a standard dialog on desktop, matching HA's native dialog
behaviour. Header slots are used for the device icon, title, and the
dots-vertical action button; the built-in close button replaces the
custom one.

https://claude.ai/code/session_016dtRyR1kzs9BmfogdYLExC