### PR TITLE
Add empty state to LyrionTrackInfo component

### DIFF
--- a/src/components/LyrionTrackInfo/LyrionTrackInfo.tsx
+++ b/src/components/LyrionTrackInfo/LyrionTrackInfo.tsx
@@ -4,6 +4,8 @@ import { useSqueezeboxMoreInfo } from "@hooks";
 import { css } from "@emotion/react";
 import { theme } from "@constants";
 import { deriveLyrionTrackBadges, getIsLmsPlayer } from "@utils";
+import { Spinner } from "@components";
+import { useIntl } from "@components/i18n";
 
 const styles = {
   trackInfo: css({
@@ -33,6 +35,10 @@ const styles = {
     backgroundColor: "transparent",
     border: `1px solid ${theme.colors.onCardDivider}`,
   }),
+  emptyState: css({
+    fontSize: 13,
+    color: theme.colors.onCardMuted,
+  }),
 };
 
 type LyrionTrackInfoProps = {
@@ -41,13 +47,14 @@ type LyrionTrackInfoProps = {
 
 export const LyrionTrackInfo = ({ lms_entity_id }: LyrionTrackInfoProps) => {
   const player = usePlayer();
+  const { t } = useIntl();
 
   const isLmsPlayer = useMemo(
     () => !!(lms_entity_id && getIsLmsPlayer(player, lms_entity_id)),
     [player, lms_entity_id]
   );
 
-  const { currentTrack } = useSqueezeboxMoreInfo({
+  const { currentTrack, loading } = useSqueezeboxMoreInfo({
     lms_entity_id: lms_entity_id ?? "",
     enabled: isLmsPlayer,
   });
@@ -57,7 +64,22 @@ export const LyrionTrackInfo = ({ lms_entity_id }: LyrionTrackInfoProps) => {
     [currentTrack]
   );
 
-  if (!derived) return null;
+  if (loading && !derived) return <Spinner />;
+
+  const hasNoBadges =
+    !derived ||
+    (derived.audioBadges.length === 0 && derived.metaBadges.length === 0);
+
+  if (hasNoBadges) {
+    return (
+      <span css={styles.emptyState}>
+        {t({
+          id: "LyrionTrackInfo.empty_state",
+          defaultMessage: "No track info available",
+        })}
+      </span>
+    );
+  }
 
   const { audioBadges, metaBadges } = derived;
 

--- a/src/components/i18n/en.json
+++ b/src/components/i18n/en.json
@@ -101,6 +101,9 @@
     "transfer_queue": "Transfer Queue",
     "select_source": "Select Source"
   },
+  "LyrionTrackInfo": {
+    "empty_state": "No track info available"
+  },
   "player_states": {
     "Off": "Off",
     "Idle": "Idle",


### PR DESCRIPTION
Shows a spinner while track info is loading and a muted "No track info available" message when there is no data (e.g. player is idle or no audio format metadata was returned).

https://claude.ai/code/session_015HHs7axyQCDggrkggHwkrh