### PR TITLE
Add sound mode selection to large card and compact card

### DIFF
--- a/src/components/AdditionalActionsMenu/AdditionalActionsMenu.tsx
+++ b/src/components/AdditionalActionsMenu/AdditionalActionsMenu.tsx
@@ -22,6 +22,7 @@ export type AdditionalActionsMenuProps = {
   ma_favorite_button_entity_id?: string;
   lms_entity_id?: string;
   noSourceSelection?: boolean;
+  noSoundModeSelection?: boolean;
 } & Omit<OverlayMenuProps, "menuItems" | "children">;
 
 export const AdditionalActionsMenu = ({
@@ -29,6 +30,7 @@ export const AdditionalActionsMenu = ({
   ma_favorite_button_entity_id,
   lms_entity_id,
   noSourceSelection,
+  noSoundModeSelection,
   ...overlayMenuProps
 }: AdditionalActionsMenuProps) => {
   const { t } = useIntl();
@@ -132,6 +134,28 @@ export const AdditionalActionsMenu = ({
         })),
       });
     }
+    if (
+      !noSoundModeSelection &&
+      player.attributes.sound_mode_list?.length &&
+      player.attributes.sound_mode_list?.length > 0
+    ) {
+      items.push({
+        label: t({
+          id: "AdditionalActionsMenu.select_sound_mode",
+        }),
+        icon: "mdi:equalizer",
+        children: (player.attributes.sound_mode_list ?? []).map(sound_mode => ({
+          label: sound_mode,
+          selected: sound_mode === player.attributes.sound_mode,
+          onClick: () => {
+            getHass().callService("media_player", "select_sound_mode", {
+              entity_id: player.entity_id,
+              sound_mode,
+            });
+          },
+        })),
+      });
+    }
     return items;
   }, [
     ma_favorite_button_entity_id,
@@ -142,7 +166,10 @@ export const AdditionalActionsMenu = ({
     markSongAsFavorite,
     transferQueue,
     noSourceSelection,
+    noSoundModeSelection,
     player.attributes.source_list,
+    player.attributes.sound_mode_list,
+    player.attributes.sound_mode,
     player.entity_id,
     t,
   ]);

--- a/src/components/MediocreLargeMultiMediaPlayerCard/components/AdditionalActionsView.tsx
+++ b/src/components/MediocreLargeMultiMediaPlayerCard/components/AdditionalActionsView.tsx
@@ -158,6 +158,23 @@ export const AdditionalActionsView = memo(() => {
     }));
   }, [player.attributes.source_list, player.entity_id]);
 
+  const soundModeMenuItems: OverlayMenuItem[] = useMemo(() => {
+    return (player.attributes.sound_mode_list ?? []).map(sound_mode => ({
+      label: sound_mode,
+      selected: sound_mode === player.attributes.sound_mode,
+      onClick: () => {
+        getHass().callService("media_player", "select_sound_mode", {
+          entity_id: player.entity_id,
+          sound_mode,
+        });
+      },
+    }));
+  }, [
+    player.attributes.sound_mode_list,
+    player.attributes.sound_mode,
+    player.entity_id,
+  ]);
+
   const moreInfoButtonProps = useActionProps({
     rootElement,
     actionConfig: {
@@ -249,6 +266,18 @@ export const AdditionalActionsView = memo(() => {
                   })}
                 >
                   {player.attributes.source}
+                  <Icon size="x-small" icon="mdi:chevron-down" />
+                </Chip>
+              )}
+            />
+          )}
+          {soundModeMenuItems.length > 0 && player.attributes.sound_mode && (
+            <OverlayMenu
+              side="bottom"
+              menuItems={soundModeMenuItems}
+              renderTrigger={triggerProps => (
+                <Chip {...triggerProps} icon="mdi:equalizer">
+                  {player.attributes.sound_mode}
                   <Icon size="x-small" icon="mdi:chevron-down" />
                 </Chip>
               )}

--- a/src/components/i18n/da.json
+++ b/src/components/i18n/da.json
@@ -97,7 +97,8 @@
   "AdditionalActionsMenu": {
     "mark_as_favorite": "Marker som favorit",
     "transfer_queue": "Overfør kø",
-    "select_source": "Vælg kilde"
+    "select_source": "Vælg kilde",
+    "select_sound_mode": "Lydtilstand"
   },
   "player_states": {
     "Off": "Slukket",

--- a/src/components/i18n/de.json
+++ b/src/components/i18n/de.json
@@ -84,7 +84,8 @@
   "AdditionalActionsMenu": {
     "mark_as_favorite": "Als Favorit markieren",
     "transfer_queue": "Wiedergabeliste übergeben",
-    "select_source": "Quelle wählen"
+    "select_source": "Quelle wählen",
+    "select_sound_mode": "Klangmodus"
   },
   "player_states": {
     "Off": "Aus",

--- a/src/components/i18n/en.json
+++ b/src/components/i18n/en.json
@@ -99,7 +99,8 @@
   "AdditionalActionsMenu": {
     "mark_as_favorite": "Mark as Favorite",
     "transfer_queue": "Transfer Queue",
-    "select_source": "Select Source"
+    "select_source": "Select Source",
+    "select_sound_mode": "Sound Mode"
   },
   "LyrionTrackInfo": {
     "empty_state": "No track info available"

--- a/src/components/i18n/nl.json
+++ b/src/components/i18n/nl.json
@@ -80,7 +80,8 @@
   "AdditionalActionsMenu": {
     "mark_as_favorite": "Markeren als favoriet",
     "transfer_queue": "Wachtrij overzetten",
-    "select_source": "Bron selecteren"
+    "select_source": "Bron selecteren",
+    "select_sound_mode": "Geluidsmodus"
   },
   "player_states": {
     "Off": "Uit",

--- a/src/components/i18n/pt.json
+++ b/src/components/i18n/pt.json
@@ -84,7 +84,8 @@
   "AdditionalActionsMenu": {
     "mark_as_favorite": "Marcar como Favorito",
     "transfer_queue": "Transferir Fila",
-    "select_source": "Selecionar Fonte"
+    "select_source": "Selecionar Fonte",
+    "select_sound_mode": "Modo de Som"
   },
   "player_states": {
     "Off": "Desligado",

--- a/src/types/mediaPlayerEntity.ts
+++ b/src/types/mediaPlayerEntity.ts
@@ -51,6 +51,8 @@ export interface MediaPlayerEntityAttributes {
   group_members?: string[]; // Array of entity_ids
   source?: string;
   source_list?: string[];
+  sound_mode?: string;
+  sound_mode_list?: string[];
   device_class?: MediaPlayerDeviceClass;
   media_content_id?: string;
   media_content_type?: MediaContentType;


### PR DESCRIPTION
Sound mode is displayed as a chip in the large card's additional actions tab
and as a submenu item in the compact card's more dropdown, mirroring the
existing source selection pattern. Only shown when sound_mode_list is present
in player attributes.

https://claude.ai/code/session_01QePBmFvApCzgh2ffnwVnuk