### PR TITLE
Internationalize the card editor + add Hebrew (he) editor translations

### DIFF
--- a/src/components/Form/components/FieldGroupCustomButtons.tsx
+++ b/src/components/Form/components/FieldGroupCustomButtons.tsx
@@ -9,6 +9,7 @@ import {
   Label,
 } from "@components/FormElements";
 import { useHass } from "@components/HassContext";
+import { useIntl } from "@components/i18n";
 import { ValidationErrorMap } from "@tanstack/react-form";
 import { useCallback } from "preact/hooks";
 
@@ -27,6 +28,7 @@ export const FieldGroupCustomButtons = withFieldGroup({
   },
   render: function Render({ group, formErrors }) {
     const hass = useHass();
+    const { t } = useIntl();
 
     const getSubformError = useCallback(
       (fieldName: string) => {
@@ -47,7 +49,7 @@ export const FieldGroupCustomButtons = withFieldGroup({
                   const stableKey = `${customButtonEntry.name}-${index}`;
                   return (
                     <SubForm
-                      title={`Button ${index} - ${customButtonEntry.name}`}
+                      title={`${t({ id: "Editor.custom_buttons.button" })} ${index} - ${customButtonEntry.name}`}
                       error={getSubformError(`custom_buttons[${index}]`)}
                       buttons={[
                         {
@@ -72,16 +74,25 @@ export const FieldGroupCustomButtons = withFieldGroup({
                       <FormGroup>
                         <group.AppField
                           name={`custom_buttons[${index}].name`}
-                          children={field => <field.Text label="Name" />}
+                          children={field => (
+                            <field.Text
+                              label={t({ id: "Editor.custom_buttons.name" })}
+                            />
+                          )}
                         />
                         <group.AppField
                           name={`custom_buttons[${index}].icon`}
                           children={field => (
-                            <field.Text label="Icon" isIconInput />
+                            <field.Text
+                              label={t({ id: "Editor.custom_buttons.icon" })}
+                              isIconInput
+                            />
                           )}
                         />
 
-                        <Label>Interactions</Label>
+                        <Label>
+                          {t({ id: "Editor.custom_buttons.interactions" })}
+                        </Label>
 
                         <group.Field name={`custom_buttons[${index}]`}>
                           {field => {
@@ -118,7 +129,7 @@ export const FieldGroupCustomButtons = withFieldGroup({
                 });
               }}
             >
-              Add Custom Button
+              {t({ id: "Editor.custom_buttons.add" })}
             </Button>
           </Fragment>
         )}

--- a/src/components/Form/components/FieldGroupMaEntities.tsx
+++ b/src/components/Form/components/FieldGroupMaEntities.tsx
@@ -1,5 +1,6 @@
 import { withFieldGroup } from "../hooks/useAppForm";
 import { Fragment } from "preact/jsx-runtime";
+import { useIntl } from "@components/i18n";
 
 type MaEntitiesFields = {
   ma_entity_id?: string | null;
@@ -15,13 +16,14 @@ export const FieldGroupMaEntities = withFieldGroup({
   defaultValues,
   props: {},
   render: function Render({ group }) {
+    const { t } = useIntl();
     return (
       <Fragment>
         <group.AppField
           name="ma_entity_id"
           children={field => (
             <field.EntityPicker
-              label="Music Assistant Entity ID (Optional)"
+              label={t({ id: "Editor.ma_entities.ma_entity_id" })}
               domains={["media_player"]}
             />
           )}
@@ -30,7 +32,7 @@ export const FieldGroupMaEntities = withFieldGroup({
           name="ma_favorite_button_entity_id"
           children={field => (
             <field.EntityPicker
-              label="MA Favorite Button Entity ID (Optional)"
+              label={t({ id: "Editor.ma_entities.ma_favorite_button" })}
               domains={["button"]}
             />
           )}

--- a/src/components/Form/components/FieldGroupMediaBrowser.tsx
+++ b/src/components/Form/components/FieldGroupMediaBrowser.tsx
@@ -4,6 +4,7 @@ import { Fragment } from "preact/jsx-runtime";
 import { SubForm } from "@components/SubForm";
 import { EntityPicker, FormGroup } from "@components/FormElements";
 import { useHass } from "@components/HassContext";
+import { useIntl } from "@components/i18n";
 
 type MediaBrowserFields = {
   media_browser: MediaBrowserConfig;
@@ -18,6 +19,7 @@ export const FieldGroupMediaBrowser = withFieldGroup({
   props: {},
   render: function Render({ group }) {
     const hass = useHass();
+    const { t } = useIntl();
 
     return (
       <group.Field name="media_browser" mode="array">
@@ -30,7 +32,7 @@ export const FieldGroupMediaBrowser = withFieldGroup({
                     title={
                       mediaBrowserEntry.name ??
                       mediaBrowserEntry.entity_id ??
-                      `Entry ${index}`
+                      `${t({ id: "Editor.media_browser.entry" })} ${index}`
                     }
                     buttons={[
                       {
@@ -55,13 +57,17 @@ export const FieldGroupMediaBrowser = withFieldGroup({
                     <FormGroup>
                       <group.AppField
                         name={`media_browser[${index}].name`}
-                        children={field => <field.Text label={"Name"} />}
+                        children={field => (
+                          <field.Text
+                            label={t({ id: "Editor.media_browser.name" })}
+                          />
+                        )}
                       />
                       <group.AppField
                         name={`media_browser[${index}].entity_id`}
                         children={field => (
                           <field.EntityPicker
-                            label={"Media Browser Entity ID"}
+                            label={t({ id: "Editor.media_browser.entity_id" })}
                             domains={["media_player"]}
                           />
                         )}
@@ -81,7 +87,7 @@ export const FieldGroupMediaBrowser = withFieldGroup({
                     hass.states[value]?.attributes.friendly_name ?? undefined,
                 });
               }}
-              label="Add Media Browser"
+              label={t({ id: "Editor.media_browser.add" })}
               domains={["media_player"]}
             />
           </Fragment>

--- a/src/components/Form/components/FieldGroupSearch.tsx
+++ b/src/components/Form/components/FieldGroupSearch.tsx
@@ -5,6 +5,7 @@ import { EntityPicker, FormGroup } from "@components/FormElements";
 import { HaSearchMediaTypesEditor } from "@components/HaSearch/HaSearchMediaTypesEditor";
 import { useHass } from "@components/HassContext";
 import { SubForm } from "@components/SubForm";
+import { useIntl } from "@components/i18n";
 
 type SearchGroupFields = {
   search: SearchConfig;
@@ -21,6 +22,7 @@ export const FieldGroupSearch = withFieldGroup({
   props: {},
   render: function Render({ group }) {
     const hass = useHass();
+    const { t } = useIntl();
 
     return (
       <group.Field name="search" mode="array">
@@ -33,7 +35,7 @@ export const FieldGroupSearch = withFieldGroup({
                     title={
                       searchEntry.name ??
                       searchEntry.entity_id ??
-                      `Entry ${index}`
+                      `${t({ id: "Editor.search.entry" })} ${index}`
                     }
                     buttons={[
                       {
@@ -58,13 +60,15 @@ export const FieldGroupSearch = withFieldGroup({
                     <FormGroup>
                       <group.AppField
                         name={`search[${index}].name`}
-                        children={field => <field.Text label={"Name"} />}
+                        children={field => (
+                          <field.Text label={t({ id: "Editor.search.name" })} />
+                        )}
                       />
                       <group.AppField
                         name={`search[${index}].entity_id`}
                         children={field => (
                           <field.EntityPicker
-                            label={"Media Player Entity ID (to search)"}
+                            label={t({ id: "Editor.search.entity_id" })}
                             domains={["media_player"]}
                             required
                           />
@@ -99,7 +103,7 @@ export const FieldGroupSearch = withFieldGroup({
                     hass.states[value]?.attributes.friendly_name ?? "Search",
                 });
               }}
-              label="Add Search"
+              label={t({ id: "Editor.search.add" })}
               domains={["media_player"]}
             />
           </Fragment>

--- a/src/components/FormElements/ActionsConfigurator.tsx
+++ b/src/components/FormElements/ActionsConfigurator.tsx
@@ -2,6 +2,7 @@ import { HomeAssistant } from "@types";
 import { useCallback, useEffect, useMemo, useRef } from "preact/hooks";
 import { InteractionConfig } from "@types";
 import { getActionsFormSchema } from "./actionsSchema";
+import { useIntl } from "@components/i18n";
 
 export type ActionsConfiguratorProps = {
   hass: HomeAssistant;
@@ -16,6 +17,7 @@ export const ActionsConfigurator = ({
   onChange,
   disabled = false,
 }: ActionsConfiguratorProps) => {
+  const { t } = useIntl();
   const formRef = useRef<HTMLElement | null>(null);
 
   // Transform ActionConfig to data format for ha-form
@@ -59,7 +61,7 @@ export const ActionsConfigurator = ({
       ref={formRef}
       hass={hass}
       data={data}
-      schema={getActionsFormSchema()}
+      schema={getActionsFormSchema(t)}
       computeLabel={item => item.label || item.name}
       disabled={disabled}
     />

--- a/src/components/FormElements/EntitiesPicker.tsx
+++ b/src/components/FormElements/EntitiesPicker.tsx
@@ -3,6 +3,7 @@ import { useCallback, useMemo } from "preact/hooks";
 import { EntityPicker } from "./EntityPicker";
 import { css } from "@emotion/react";
 import { TextInput } from "./TextInput";
+import { useIntl } from "@components/i18n";
 
 const styles = {
   root: css({
@@ -36,6 +37,7 @@ export const EntitiesPicker = ({
   disabled = false,
   allowCustomEntity = false,
 }: EntitiesPickerProps) => {
+  const { t } = useIntl();
   // Filter out undefined/null values
   const entities = useMemo(() => {
     const values = value?.filter(Boolean) || [];
@@ -111,7 +113,7 @@ export const EntitiesPicker = ({
             value={entity.name ?? ""}
             onChange={newValue => handleNameChange(newValue, index)}
             disabled={disabled}
-            label="Name"
+            label={t({ id: "Editor.entities_picker.name" })}
           />
           <EntityPicker
             hass={hass}

--- a/src/components/FormElements/actionsSchema.ts
+++ b/src/components/FormElements/actionsSchema.ts
@@ -1,21 +1,23 @@
 // Thanks to mushroom card for the inspiration
 // very hard to find documentation for ha-form
 
-export const getActionsFormSchema = () => {
+type TranslateFn = (args: { id: string; defaultMessage?: string }) => string;
+
+export const getActionsFormSchema = (t: TranslateFn) => {
   return [
     {
       name: "tap_action",
-      label: "Tap Action",
+      label: t({ id: "Editor.actions.tap_action" }),
       selector: { ui_action: {} },
     },
     {
       name: "hold_action",
-      label: "Hold Action",
+      label: t({ id: "Editor.actions.hold_action" }),
       selector: { ui_action: {} },
     },
     {
       name: "double_tap_action",
-      label: "Double Tap Action",
+      label: t({ id: "Editor.actions.double_tap_action" }),
       selector: { ui_action: {} },
     },
   ];

--- a/src/components/MediocreMassiveMediaPlayerCard/MediocreMassiveMediaPlayerCardEditor.tsx
+++ b/src/components/MediocreMassiveMediaPlayerCard/MediocreMassiveMediaPlayerCardEditor.tsx
@@ -6,6 +6,7 @@ import { MediocreMassiveMediaPlayerCardConfig } from "@types";
 import { useCallback, useEffect } from "preact/hooks";
 import { useStore, ValidationErrorMap } from "@tanstack/react-form";
 import { FormGroup, SubForm, FormSelect } from "@components";
+import { useIntl } from "@components/i18n";
 import { css } from "@emotion/react";
 import { FC } from "preact/compat";
 import {
@@ -27,6 +28,7 @@ export type MediocreMassiveMediaPlayerCardEditorProps = {
 export const MediocreMassiveMediaPlayerCardEditor: FC<
   MediocreMassiveMediaPlayerCardEditorProps
 > = ({ config, rootElement, hass }) => {
+  const { t } = useIntl();
   const updateConfig = useCallback(
     (newConfig: MediocreMassiveMediaPlayerCardConfig) => {
       const event = new Event("config-changed", {
@@ -96,7 +98,7 @@ export const MediocreMassiveMediaPlayerCardEditor: FC<
         name="entity_id"
         children={field => (
           <field.EntityPicker
-            label="Media Player Entity"
+            label={t({ id: "Editor.common.media_player_entity" })}
             required
             domains={["media_player"]}
           />
@@ -112,15 +114,17 @@ export const MediocreMassiveMediaPlayerCardEditor: FC<
       >
         <form.AppField
           name="use_art_colors"
-          children={field => <field.Toggle label="Use album art colors." />}
+          children={field => (
+            <field.Toggle label={t({ id: "Editor.common.use_art_colors" })} />
+          )}
         />
         <form.Field name="mode">
           {field => (
             <FormSelect
               options={[
-                { name: "Panel", value: "panel" },
-                { name: "Card", value: "card" },
-                { name: "In Card", value: "in-card" },
+                { name: t({ id: "Editor.select.panel" }), value: "panel" },
+                { name: t({ id: "Editor.select.card" }), value: "card" },
+                { name: t({ id: "Editor.select.in_card" }), value: "in-card" },
               ]}
               onSelected={value =>
                 field.handleChange(
@@ -133,7 +137,10 @@ export const MediocreMassiveMediaPlayerCardEditor: FC<
         </form.Field>
       </FormGroup>
 
-      <SubForm title="Interactions" error={getSubformError("action")}>
+      <SubForm
+        title={t({ id: "Editor.common.interactions" })}
+        error={getSubformError("action")}
+      >
         <form.AppField
           name="action"
           children={field => <field.InteractionsPicker />}
@@ -141,14 +148,14 @@ export const MediocreMassiveMediaPlayerCardEditor: FC<
       </SubForm>
 
       <SubForm
-        title="Speaker Group Configuration (optional)"
+        title={t({ id: "Editor.common.speaker_group_config" })}
         error={getSubformError("speaker_group")}
       >
         <form.AppField
           name="speaker_group.entity_id"
           children={field => (
             <field.EntityPicker
-              label="Main Speaker Entity ID (Optional)"
+              label={t({ id: "Editor.common.main_speaker_entity" })}
               domains={["media_player"]}
             />
           )}
@@ -157,7 +164,7 @@ export const MediocreMassiveMediaPlayerCardEditor: FC<
           name="speaker_group.entities"
           children={field => (
             <field.EntitiesPicker
-              label="Select Speakers (including main speaker)"
+              label={t({ id: "Editor.common.select_speakers" })}
               domains={["media_player"]}
             />
           )}
@@ -165,7 +172,7 @@ export const MediocreMassiveMediaPlayerCardEditor: FC<
       </SubForm>
 
       <SubForm
-        title="Music Assistant Configuration (optional)"
+        title={t({ id: "Editor.common.ma_config" })}
         error={
           getSubformError("ma_entity_id") ??
           getSubformError("ma_favorite_button_entity_id")
@@ -180,20 +187,23 @@ export const MediocreMassiveMediaPlayerCardEditor: FC<
         />
       </SubForm>
       <SubForm
-        title="LMS Configuration (optional)"
+        title={t({ id: "Editor.common.lms_config" })}
         error={getSubformError("lms_entity_id")}
       >
         <form.AppField
           name="lms_entity_id"
           children={field => (
             <field.EntityPicker
-              label="LMS Media Player Entity ID"
+              label={t({ id: "Editor.common.lms_entity" })}
               domains={["media_player"]}
             />
           )}
         />
       </SubForm>
-      <SubForm title="Search (optional)" error={getSubformError("search")}>
+      <SubForm
+        title={t({ id: "Editor.common.search_optional" })}
+        error={getSubformError("search")}
+      >
         <FieldGroupSearch
           form={form}
           fields={{ search: "search", ma_entity_id: "ma_entity_id" }}
@@ -201,7 +211,7 @@ export const MediocreMassiveMediaPlayerCardEditor: FC<
       </SubForm>
 
       <SubForm
-        title="Media Browser (optional)"
+        title={t({ id: "Editor.common.media_browser_optional" })}
         error={getSubformError("media_browser")}
       >
         <FieldGroupMediaBrowser
@@ -211,7 +221,7 @@ export const MediocreMassiveMediaPlayerCardEditor: FC<
       </SubForm>
 
       <SubForm
-        title="Custom Buttons (optional)"
+        title={t({ id: "Editor.common.custom_buttons_optional" })}
         error={getSubformError("custom_buttons")}
       >
         <FieldGroupCustomButtons
@@ -221,29 +231,39 @@ export const MediocreMassiveMediaPlayerCardEditor: FC<
         />
       </SubForm>
       <SubForm
-        title="Additional options (optional)"
+        title={t({ id: "Editor.common.additional_options" })}
         error={getSubformError("options")}
       >
         <form.AppField
           name="options.always_show_power_button"
-          children={field => <field.Toggle label="Always show power button." />}
+          children={field => (
+            <field.Toggle
+              label={t({ id: "Editor.options.always_show_power_button" })}
+            />
+          )}
         />
         <form.AppField
           name="options.show_volume_step_buttons"
           children={field => (
-            <field.Toggle label="Show volume step buttons + - on volume sliders" />
+            <field.Toggle
+              label={t({ id: "Editor.options.show_volume_step_buttons" })}
+            />
           )}
         />
         <form.AppField
           name="options.use_volume_up_down_for_step_buttons"
           children={field => (
-            <field.Toggle label="Use volume_up and volume_down services for step buttons (breaks volume sync when step buttons are used)" />
+            <field.Toggle
+              label={t({ id: "Editor.options.use_volume_up_down" })}
+            />
           )}
         />
         <form.AppField
           name="options.use_experimental_lms_media_browser"
           children={field => (
-            <field.Toggle label="Use experimental LMS media browser (requires lyrion_cli integration)" />
+            <field.Toggle
+              label={t({ id: "Editor.options.use_experimental_lms" })}
+            />
           )}
         />
       </SubForm>

--- a/src/components/MediocreMediaPlayerCard/MediocreMediaPlayerCardEditor.tsx
+++ b/src/components/MediocreMediaPlayerCard/MediocreMediaPlayerCardEditor.tsx
@@ -3,6 +3,7 @@ import { MediocreMediaPlayerCardConfig } from "@types";
 import { useCallback, useEffect } from "preact/hooks";
 import { useStore, ValidationErrorMap } from "@tanstack/react-form";
 import { FormGroup, Label, SubForm } from "@components";
+import { useIntl } from "@components/i18n";
 import { css } from "@emotion/react";
 import { FC } from "preact/compat";
 import {
@@ -24,6 +25,7 @@ export type MediocreMediaPlayerCardEditorProps = {
 export const MediocreMediaPlayerCardEditor: FC<
   MediocreMediaPlayerCardEditorProps
 > = ({ config, rootElement, hass }) => {
+  const { t } = useIntl();
   const updateConfig = useCallback(
     (newConfig: MediocreMediaPlayerCardConfig) => {
       const event = new Event("config-changed", {
@@ -94,7 +96,7 @@ export const MediocreMediaPlayerCardEditor: FC<
         name="entity_id"
         children={field => (
           <field.EntityPicker
-            label="Media Player Entity"
+            label={t({ id: "Editor.common.media_player_entity" })}
             required
             domains={["media_player"]}
           />
@@ -103,7 +105,9 @@ export const MediocreMediaPlayerCardEditor: FC<
 
       <form.AppField
         name="name"
-        children={field => <field.Text label="Name (optional)" />}
+        children={field => (
+          <field.Text label={t({ id: "Editor.common.name_optional" })} />
+        )}
       />
 
       <FormGroup
@@ -111,20 +115,27 @@ export const MediocreMediaPlayerCardEditor: FC<
       >
         <form.AppField
           name="use_art_colors"
-          children={field => <field.Toggle label="Use album art colors." />}
+          children={field => (
+            <field.Toggle label={t({ id: "Editor.common.use_art_colors" })} />
+          )}
         />
         <form.AppField
           name="tap_opens_popup"
-          children={field => <field.Toggle label="Tap opens popup." />}
+          children={field => (
+            <field.Toggle label={t({ id: "Editor.common.tap_opens_popup" })} />
+          )}
         />
       </FormGroup>
 
-      <SubForm title="Interactions" error={getSubformError("action")}>
+      <SubForm
+        title={t({ id: "Editor.common.interactions" })}
+        error={getSubformError("action")}
+      >
         <form.Field
           name="tap_opens_popup"
           children={tapField =>
             tapField.state.value && (
-              <Label>Tap action overridden by "tap opens popup".</Label>
+              <Label>{t({ id: "Editor.common.tap_action_overridden" })}</Label>
             )
           }
         />
@@ -135,14 +146,14 @@ export const MediocreMediaPlayerCardEditor: FC<
       </SubForm>
 
       <SubForm
-        title="Speaker Group Configuration (optional)"
+        title={t({ id: "Editor.common.speaker_group_config" })}
         error={getSubformError("speaker_group")}
       >
         <form.AppField
           name="speaker_group.entity_id"
           children={field => (
             <field.EntityPicker
-              label="Main Speaker Entity ID (Optional)"
+              label={t({ id: "Editor.common.main_speaker_entity" })}
               domains={["media_player"]}
             />
           )}
@@ -151,7 +162,7 @@ export const MediocreMediaPlayerCardEditor: FC<
           name="speaker_group.entities"
           children={field => (
             <field.EntitiesPicker
-              label="Select Speakers (including main speaker)"
+              label={t({ id: "Editor.common.select_speakers" })}
               domains={["media_player"]}
             />
           )}
@@ -159,7 +170,7 @@ export const MediocreMediaPlayerCardEditor: FC<
       </SubForm>
 
       <SubForm
-        title="Music Assistant Configuration (optional)"
+        title={t({ id: "Editor.common.ma_config" })}
         error={
           getSubformError("ma_entity_id") ??
           getSubformError("ma_favorite_button_entity_id")
@@ -174,27 +185,30 @@ export const MediocreMediaPlayerCardEditor: FC<
         />
       </SubForm>
       <SubForm
-        title="LMS Configuration (optional)"
+        title={t({ id: "Editor.common.lms_config" })}
         error={getSubformError("lms_entity_id")}
       >
         <form.AppField
           name="lms_entity_id"
           children={field => (
             <field.EntityPicker
-              label="LMS Media Player Entity ID"
+              label={t({ id: "Editor.common.lms_entity" })}
               domains={["media_player"]}
             />
           )}
         />
       </SubForm>
-      <SubForm title="Search (optional)" error={getSubformError("search")}>
+      <SubForm
+        title={t({ id: "Editor.common.search_optional" })}
+        error={getSubformError("search")}
+      >
         <FieldGroupSearch
           form={form}
           fields={{ search: "search", ma_entity_id: "ma_entity_id" }}
         />
       </SubForm>
       <SubForm
-        title="Media Browser (optional)"
+        title={t({ id: "Editor.common.media_browser_optional" })}
         error={getSubformError("media_browser")}
       >
         <FieldGroupMediaBrowser
@@ -203,7 +217,7 @@ export const MediocreMediaPlayerCardEditor: FC<
         />
       </SubForm>
       <SubForm
-        title="Custom Buttons (optional)"
+        title={t({ id: "Editor.common.custom_buttons_optional" })}
         error={getSubformError("custom_buttons")}
       >
         <FieldGroupCustomButtons
@@ -213,47 +227,61 @@ export const MediocreMediaPlayerCardEditor: FC<
         />
       </SubForm>
       <SubForm
-        title="Additional options (optional)"
+        title={t({ id: "Editor.common.additional_options" })}
         error={getSubformError("options")}
       >
         <form.AppField
           name="options.always_show_power_button"
-          children={field => <field.Toggle label="Always show power button." />}
+          children={field => (
+            <field.Toggle
+              label={t({ id: "Editor.options.always_show_power_button" })}
+            />
+          )}
         />
         <form.AppField
           name="options.always_show_custom_buttons"
           children={field => (
-            <field.Toggle label="Always show custom buttons panel below card" />
+            <field.Toggle
+              label={t({ id: "Editor.options.always_show_custom_buttons" })}
+            />
           )}
         />
         <form.AppField
           name="options.hide_when_off"
           children={field => (
-            <field.Toggle label="Hide when media player is off" />
+            <field.Toggle label={t({ id: "Editor.options.hide_when_off" })} />
           )}
         />
         <form.AppField
           name="options.hide_when_group_child"
           children={field => (
-            <field.Toggle label="Hide when media player is a group child" />
+            <field.Toggle
+              label={t({ id: "Editor.options.hide_when_group_child" })}
+            />
           )}
         />
         <form.AppField
           name="options.show_volume_step_buttons"
           children={field => (
-            <field.Toggle label="Show volume step buttons + - on volume sliders" />
+            <field.Toggle
+              label={t({ id: "Editor.options.show_volume_step_buttons" })}
+            />
           )}
         />
         <form.AppField
           name="options.use_volume_up_down_for_step_buttons"
           children={field => (
-            <field.Toggle label="Use volume_up and volume_down services for step buttons (breaks volume sync when step buttons are used)" />
+            <field.Toggle
+              label={t({ id: "Editor.options.use_volume_up_down" })}
+            />
           )}
         />
         <form.AppField
           name="options.use_experimental_lms_media_browser"
           children={field => (
-            <field.Toggle label="Use experimental LMS media browser (requires lyrion_cli integration)" />
+            <field.Toggle
+              label={t({ id: "Editor.options.use_experimental_lms" })}
+            />
           )}
         />
       </SubForm>

--- a/src/components/MediocreMultiMediaPlayerCard/MediocreMultiMediaPlayerCardEditor.tsx
+++ b/src/components/MediocreMultiMediaPlayerCard/MediocreMultiMediaPlayerCardEditor.tsx
@@ -13,6 +13,7 @@ import {
   Button,
   Label,
 } from "@components";
+import { useIntl } from "@components/i18n";
 import { css } from "@emotion/react";
 import { FC, Fragment } from "preact/compat";
 import { getAllMassPlayers } from "@utils";
@@ -32,6 +33,7 @@ export type MediocreMultiMediaPlayerCardEditorProps = {
 export const MediocreMultiMediaPlayerCardEditor: FC<
   MediocreMultiMediaPlayerCardEditorProps
 > = ({ config, rootElement, hass }) => {
+  const { t } = useIntl();
   const updateConfigTimeout = useRef<number | null>(null);
   const updateConfig = useCallback(
     (newConfig: MediocreMultiMediaPlayerCardConfig) => {
@@ -174,7 +176,7 @@ export const MediocreMultiMediaPlayerCardEditor: FC<
         name="entity_id"
         children={field => (
           <field.EntityPicker
-            label="Default Media Player (used when no media player is active)"
+            label={t({ id: "Editor.multi.default_media_player" })}
             required
             domains={["media_player"]}
           />
@@ -190,14 +192,19 @@ export const MediocreMultiMediaPlayerCardEditor: FC<
       >
         <form.AppField
           name="use_art_colors"
-          children={field => <field.Toggle label="Use album art colors." />}
+          children={field => (
+            <field.Toggle label={t({ id: "Editor.common.use_art_colors" })} />
+          )}
         />
         <form.Field name="size">
           {field => (
             <FormSelect
               options={[
-                { name: "Large", value: "large" },
-                { name: "Compact", value: "compact" },
+                { name: t({ id: "Editor.select.large" }), value: "large" },
+                {
+                  name: t({ id: "Editor.select.compact" }),
+                  value: "compact",
+                },
               ]}
               onSelected={value =>
                 field.handleChange(value as "large" | "compact")
@@ -209,7 +216,11 @@ export const MediocreMultiMediaPlayerCardEditor: FC<
         {size === "compact" && (
           <form.AppField
             name="tap_opens_popup"
-            children={field => <field.Toggle label="Tap opens popup." />}
+            children={field => (
+              <field.Toggle
+                label={t({ id: "Editor.common.tap_opens_popup" })}
+              />
+            )}
           />
         )}
         {size === "large" && (
@@ -217,8 +228,8 @@ export const MediocreMultiMediaPlayerCardEditor: FC<
             {field => (
               <FormSelect
                 options={[
-                  { name: "Panel", value: "panel" },
-                  { name: "Card", value: "card" },
+                  { name: t({ id: "Editor.select.panel" }), value: "panel" },
+                  { name: t({ id: "Editor.select.card" }), value: "card" },
                 ]}
                 onSelected={value =>
                   field.handleChange(value as "panel" | "card")
@@ -229,7 +240,10 @@ export const MediocreMultiMediaPlayerCardEditor: FC<
           </form.Field>
         )}
       </FormGroup>
-      <SubForm title="Media Players" error={getSubformError("media_players")}>
+      <SubForm
+        title={t({ id: "Editor.multi.media_players" })}
+        error={getSubformError("media_players")}
+      >
         <form.Field name="media_players" mode="array">
           {field => {
             return (
@@ -242,7 +256,7 @@ export const MediocreMultiMediaPlayerCardEditor: FC<
                         hass.states[mediaPlayer.entity_id]?.attributes
                           .friendly_name ||
                         mediaPlayer.entity_id ||
-                        "Media Player"
+                        t({ id: "Editor.multi.media_player_fallback" })
                       }
                       buttons={[
                         {
@@ -267,14 +281,18 @@ export const MediocreMultiMediaPlayerCardEditor: FC<
                         <form.AppField
                           name={`media_players[${index}].name`}
                           children={subField => (
-                            <subField.Text label="Name (optional)" />
+                            <subField.Text
+                              label={t({ id: "Editor.common.name_optional" })}
+                            />
                           )}
                         />
                         <form.AppField
                           name={`media_players[${index}].speaker_group_entity_id`}
                           children={subField => (
                             <subField.EntityPicker
-                              label="Group Media Player (if different from above)"
+                              label={t({
+                                id: "Editor.multi.group_media_player",
+                              })}
                               domains={["media_player"]}
                             />
                           )}
@@ -282,12 +300,14 @@ export const MediocreMultiMediaPlayerCardEditor: FC<
                         <form.AppField
                           name={`media_players[${index}].can_be_grouped`}
                           children={subField => (
-                            <subField.Toggle label="Enable speaker grouping (joining) for this player" />
+                            <subField.Toggle
+                              label={t({ id: "Editor.multi.enable_grouping" })}
+                            />
                           )}
                         />
                       </FormGroup>
                       <SubForm
-                        title="Music Assistant Integration (optional)"
+                        title={t({ id: "Editor.multi.ma_integration" })}
                         error={
                           getSubformError(
                             `media_players[${index}].ma_entity_id`
@@ -306,7 +326,7 @@ export const MediocreMultiMediaPlayerCardEditor: FC<
                         />
                       </SubForm>
                       <SubForm
-                        title="LMS Configuration (optional)"
+                        title={t({ id: "Editor.common.lms_config" })}
                         error={getSubformError(
                           `media_players[${index}].lms_entity_id`
                         )}
@@ -315,14 +335,14 @@ export const MediocreMultiMediaPlayerCardEditor: FC<
                           name={`media_players[${index}].lms_entity_id`}
                           children={field => (
                             <field.EntityPicker
-                              label="LMS Media Player Entity ID"
+                              label={t({ id: "Editor.common.lms_entity" })}
                               domains={["media_player"]}
                             />
                           )}
                         />
                       </SubForm>
                       <SubForm
-                        title="Search Configuration (optional) (not for music assistant)"
+                        title={t({ id: "Editor.multi.search_config" })}
                         error={getSubformError(
                           `media_players[${index}].search`
                         )}
@@ -336,7 +356,9 @@ export const MediocreMultiMediaPlayerCardEditor: FC<
                         />
                       </SubForm>
                       <SubForm
-                        title="Media Browser (optional)"
+                        title={t({
+                          id: "Editor.common.media_browser_optional",
+                        })}
                         error={getSubformError(
                           `media_players[${index}].media_browser`
                         )}
@@ -351,7 +373,9 @@ export const MediocreMultiMediaPlayerCardEditor: FC<
                       </SubForm>
 
                       <SubForm
-                        title="Custom Buttons (optional)"
+                        title={t({
+                          id: "Editor.common.custom_buttons_optional",
+                        })}
                         error={getSubformError(
                           `media_players[${index}].custom_buttons`
                         )}
@@ -385,10 +409,10 @@ export const MediocreMultiMediaPlayerCardEditor: FC<
                         field.pushValue({ entity_id: value });
                       }
                     }}
-                    label="Add a new media player"
+                    label={t({ id: "Editor.multi.add_media_player" })}
                     domains={["media_player"]}
                   />
-                  <span>or</span>
+                  <span>{t({ id: "Editor.multi.or" })}</span>
                   <Button
                     onClick={() => {
                       const newPlayers = getMusicAssistantPlayers();
@@ -397,7 +421,7 @@ export const MediocreMultiMediaPlayerCardEditor: FC<
                       });
                     }}
                   >
-                    Add all Music Assistant media players
+                    {t({ id: "Editor.multi.add_all_ma" })}
                   </Button>
                 </div>
               </Fragment>
@@ -405,18 +429,25 @@ export const MediocreMultiMediaPlayerCardEditor: FC<
           }}
         </form.Field>
       </SubForm>
-      <SubForm title="Advanced" error={getSubformError("height")}>
+      <SubForm
+        title={t({ id: "Editor.multi.advanced" })}
+        error={getSubformError("height")}
+      >
         <FormGroup>
           {size === "large" && (
             <Fragment>
               <form.AppField
                 name="height"
-                children={field => <field.Text label="Height" />}
+                children={field => (
+                  <field.Text label={t({ id: "Editor.multi.height" })} />
+                )}
               />
               <form.AppField
                 name="options.transparent_background_on_home"
                 children={field => (
-                  <field.Toggle label="Hide the card background on the home tab (massive player)" />
+                  <field.Toggle
+                    label={t({ id: "Editor.multi.transparent_background" })}
+                  />
                 )}
               />
               <form.Field name="options.default_tab">
@@ -430,15 +461,33 @@ export const MediocreMultiMediaPlayerCardEditor: FC<
                       justifyContent: "space-between",
                     })}
                   >
-                    <Label>Default tab:</Label>
+                    <Label>{t({ id: "Editor.multi.default_tab" })}</Label>
                     <FormSelect
                       options={[
-                        { name: "Home", value: "massive" },
-                        { name: "Search", value: "search" },
-                        { name: "Media Browser", value: "media-browser" },
-                        { name: "Queue", value: "queue" },
-                        { name: "Custom Buttons", value: "custom-buttons" },
-                        { name: "Speaker Grouping", value: "speaker-grouping" },
+                        {
+                          name: t({ id: "Editor.select.home" }),
+                          value: "massive",
+                        },
+                        {
+                          name: t({ id: "Editor.select.search" }),
+                          value: "search",
+                        },
+                        {
+                          name: t({ id: "Editor.select.media_browser" }),
+                          value: "media-browser",
+                        },
+                        {
+                          name: t({ id: "Editor.select.queue" }),
+                          value: "queue",
+                        },
+                        {
+                          name: t({ id: "Editor.select.custom_buttons" }),
+                          value: "custom-buttons",
+                        },
+                        {
+                          name: t({ id: "Editor.select.speaker_grouping" }),
+                          value: "speaker-grouping",
+                        },
                       ]}
                       onSelected={value =>
                         field.handleChange(
@@ -463,25 +512,35 @@ export const MediocreMultiMediaPlayerCardEditor: FC<
               <form.AppField
                 name="options.always_show_power_button"
                 children={field => (
-                  <field.Toggle label="Always show power button." />
+                  <field.Toggle
+                    label={t({ id: "Editor.options.always_show_power_button" })}
+                  />
                 )}
               />
               <form.AppField
                 name="options.always_show_custom_buttons"
                 children={field => (
-                  <field.Toggle label="Always show custom buttons panel below card" />
+                  <field.Toggle
+                    label={t({
+                      id: "Editor.options.always_show_custom_buttons",
+                    })}
+                  />
                 )}
               />
               <form.AppField
                 name="options.hide_when_off"
                 children={field => (
-                  <field.Toggle label="Hide when media player is off" />
+                  <field.Toggle
+                    label={t({ id: "Editor.options.hide_when_off" })}
+                  />
                 )}
               />
               <form.AppField
                 name="options.hide_when_group_child"
                 children={field => (
-                  <field.Toggle label="Hide when media player is a group child" />
+                  <field.Toggle
+                    label={t({ id: "Editor.options.hide_when_group_child" })}
+                  />
                 )}
               />
             </Fragment>
@@ -489,19 +548,25 @@ export const MediocreMultiMediaPlayerCardEditor: FC<
           <form.AppField
             name="options.show_volume_step_buttons"
             children={field => (
-              <field.Toggle label="Show volume step buttons + - on volume sliders" />
+              <field.Toggle
+                label={t({ id: "Editor.options.show_volume_step_buttons" })}
+              />
             )}
           />
           <form.AppField
             name="options.use_volume_up_down_for_step_buttons"
             children={field => (
-              <field.Toggle label="Use volume_up and volume_down services for step buttons (breaks volume sync when step buttons are used)" />
+              <field.Toggle
+                label={t({ id: "Editor.options.use_volume_up_down" })}
+              />
             )}
           />
           <form.AppField
             name="options.use_experimental_lms_media_browser"
             children={field => (
-              <field.Toggle label="Use experimental LMS media browser (requires lyrion_cli integration)" />
+              <field.Toggle
+                label={t({ id: "Editor.options.use_experimental_lms" })}
+              />
             )}
           />
           <form.Field name="options.player_is_active_when">
@@ -515,11 +580,17 @@ export const MediocreMultiMediaPlayerCardEditor: FC<
                   justifyContent: "space-between",
                 })}
               >
-                <Label>Consider player active when:</Label>
+                <Label>{t({ id: "Editor.multi.player_active_when" })}</Label>
                 <FormSelect
                   options={[
-                    { name: "Playing", value: "playing" },
-                    { name: "Playing or Paused", value: "playing_or_paused" },
+                    {
+                      name: t({ id: "Editor.select.playing" }),
+                      value: "playing",
+                    },
+                    {
+                      name: t({ id: "Editor.select.playing_or_paused" }),
+                      value: "playing_or_paused",
+                    },
                   ]}
                   onSelected={value =>
                     field.handleChange(value as "playing" | "playing_or_paused")

--- a/src/components/i18n/TRANSLATION_STATUS.md
+++ b/src/components/i18n/TRANSLATION_STATUS.md
@@ -6,21 +6,166 @@
 
 | Language | Keys translated | Completion | Status |
 |----------|----------------|------------|--------|
-| he | 69 / 69 | 100% ██████████ | ✅ |
-| nl | 69 / 69 | 100% ██████████ | ✅ |
-| da | 66 / 69 | 96% ██████████ | 🟡 |
-| de | 59 / 69 | 86% █████████░ | 🟡 |
-| pt | 59 / 69 | 86% █████████░ | 🟡 |
+| he | 140 / 140 | 100% ██████████ | ✅ |
+| nl | 69 / 140 | 49% █████░░░░░ | 🔴 |
+| da | 66 / 140 | 47% █████░░░░░ | 🔴 |
+| de | 59 / 140 | 42% ████░░░░░░ | 🔴 |
+| pt | 59 / 140 | 42% ████░░░░░░ | 🔴 |
 
-_Total English keys: 69_
+_Total English keys: 140_
 
 ## Missing keys per language
+
+### nl
+
+  - `Editor.common.media_player_entity`
+  - `Editor.common.name_optional`
+  - `Editor.common.name`
+  - `Editor.common.use_art_colors`
+  - `Editor.common.tap_opens_popup`
+  - `Editor.common.interactions`
+  - `Editor.common.tap_action_overridden`
+  - `Editor.common.speaker_group_config`
+  - `Editor.common.main_speaker_entity`
+  - `Editor.common.select_speakers`
+  - `Editor.common.ma_config`
+  - `Editor.common.lms_config`
+  - `Editor.common.lms_entity`
+  - `Editor.common.search_optional`
+  - `Editor.common.media_browser_optional`
+  - `Editor.common.custom_buttons_optional`
+  - `Editor.common.additional_options`
+  - `Editor.options.always_show_power_button`
+  - `Editor.options.always_show_custom_buttons`
+  - `Editor.options.hide_when_off`
+  - `Editor.options.hide_when_group_child`
+  - `Editor.options.show_volume_step_buttons`
+  - `Editor.options.use_volume_up_down`
+  - `Editor.options.use_experimental_lms`
+  - `Editor.ma_entities.ma_entity_id`
+  - `Editor.ma_entities.ma_favorite_button`
+  - `Editor.media_browser.name`
+  - `Editor.media_browser.entity_id`
+  - `Editor.media_browser.add`
+  - `Editor.media_browser.entry`
+  - `Editor.search.name`
+  - `Editor.search.entity_id`
+  - `Editor.search.add`
+  - `Editor.search.entry`
+  - `Editor.custom_buttons.name`
+  - `Editor.custom_buttons.icon`
+  - `Editor.custom_buttons.interactions`
+  - `Editor.custom_buttons.add`
+  - `Editor.custom_buttons.button`
+  - `Editor.entities_picker.name`
+  - `Editor.multi.default_media_player`
+  - `Editor.multi.media_players`
+  - `Editor.multi.media_player_fallback`
+  - `Editor.multi.ma_integration`
+  - `Editor.multi.group_media_player`
+  - `Editor.multi.enable_grouping`
+  - `Editor.multi.search_config`
+  - `Editor.multi.add_media_player`
+  - `Editor.multi.or`
+  - `Editor.multi.add_all_ma`
+  - `Editor.multi.advanced`
+  - `Editor.multi.height`
+  - `Editor.multi.transparent_background`
+  - `Editor.multi.default_tab`
+  - `Editor.multi.player_active_when`
+  - `Editor.select.panel`
+  - `Editor.select.card`
+  - `Editor.select.in_card`
+  - `Editor.select.large`
+  - `Editor.select.compact`
+  - `Editor.select.home`
+  - `Editor.select.search`
+  - `Editor.select.media_browser`
+  - `Editor.select.queue`
+  - `Editor.select.custom_buttons`
+  - `Editor.select.speaker_grouping`
+  - `Editor.select.playing`
+  - `Editor.select.playing_or_paused`
+  - `Editor.actions.tap_action`
+  - `Editor.actions.hold_action`
+  - `Editor.actions.double_tap_action`
 
 ### da
 
   - `MediocreMultiMediaPlayerCard.AdditionalActionsView.lyrion_info_title`
   - `MediocreMultiMediaPlayerCard.AdditionalActionsView.related_albums_title`
   - `LyrionTrackInfo.empty_state`
+  - `Editor.common.media_player_entity`
+  - `Editor.common.name_optional`
+  - `Editor.common.name`
+  - `Editor.common.use_art_colors`
+  - `Editor.common.tap_opens_popup`
+  - `Editor.common.interactions`
+  - `Editor.common.tap_action_overridden`
+  - `Editor.common.speaker_group_config`
+  - `Editor.common.main_speaker_entity`
+  - `Editor.common.select_speakers`
+  - `Editor.common.ma_config`
+  - `Editor.common.lms_config`
+  - `Editor.common.lms_entity`
+  - `Editor.common.search_optional`
+  - `Editor.common.media_browser_optional`
+  - `Editor.common.custom_buttons_optional`
+  - `Editor.common.additional_options`
+  - `Editor.options.always_show_power_button`
+  - `Editor.options.always_show_custom_buttons`
+  - `Editor.options.hide_when_off`
+  - `Editor.options.hide_when_group_child`
+  - `Editor.options.show_volume_step_buttons`
+  - `Editor.options.use_volume_up_down`
+  - `Editor.options.use_experimental_lms`
+  - `Editor.ma_entities.ma_entity_id`
+  - `Editor.ma_entities.ma_favorite_button`
+  - `Editor.media_browser.name`
+  - `Editor.media_browser.entity_id`
+  - `Editor.media_browser.add`
+  - `Editor.media_browser.entry`
+  - `Editor.search.name`
+  - `Editor.search.entity_id`
+  - `Editor.search.add`
+  - `Editor.search.entry`
+  - `Editor.custom_buttons.name`
+  - `Editor.custom_buttons.icon`
+  - `Editor.custom_buttons.interactions`
+  - `Editor.custom_buttons.add`
+  - `Editor.custom_buttons.button`
+  - `Editor.entities_picker.name`
+  - `Editor.multi.default_media_player`
+  - `Editor.multi.media_players`
+  - `Editor.multi.media_player_fallback`
+  - `Editor.multi.ma_integration`
+  - `Editor.multi.group_media_player`
+  - `Editor.multi.enable_grouping`
+  - `Editor.multi.search_config`
+  - `Editor.multi.add_media_player`
+  - `Editor.multi.or`
+  - `Editor.multi.add_all_ma`
+  - `Editor.multi.advanced`
+  - `Editor.multi.height`
+  - `Editor.multi.transparent_background`
+  - `Editor.multi.default_tab`
+  - `Editor.multi.player_active_when`
+  - `Editor.select.panel`
+  - `Editor.select.card`
+  - `Editor.select.in_card`
+  - `Editor.select.large`
+  - `Editor.select.compact`
+  - `Editor.select.home`
+  - `Editor.select.search`
+  - `Editor.select.media_browser`
+  - `Editor.select.queue`
+  - `Editor.select.custom_buttons`
+  - `Editor.select.speaker_grouping`
+  - `Editor.select.playing`
+  - `Editor.select.playing_or_paused`
+  - `Editor.actions.tap_action`
+  - `Editor.actions.hold_action`
+  - `Editor.actions.double_tap_action`
 
 ### de
 
@@ -34,6 +179,77 @@ _Total English keys: 69_
   - `Search.search_provider.title`
   - `Search.enqueue_mode.title`
   - `LyrionTrackInfo.empty_state`
+  - `Editor.common.media_player_entity`
+  - `Editor.common.name_optional`
+  - `Editor.common.name`
+  - `Editor.common.use_art_colors`
+  - `Editor.common.tap_opens_popup`
+  - `Editor.common.interactions`
+  - `Editor.common.tap_action_overridden`
+  - `Editor.common.speaker_group_config`
+  - `Editor.common.main_speaker_entity`
+  - `Editor.common.select_speakers`
+  - `Editor.common.ma_config`
+  - `Editor.common.lms_config`
+  - `Editor.common.lms_entity`
+  - `Editor.common.search_optional`
+  - `Editor.common.media_browser_optional`
+  - `Editor.common.custom_buttons_optional`
+  - `Editor.common.additional_options`
+  - `Editor.options.always_show_power_button`
+  - `Editor.options.always_show_custom_buttons`
+  - `Editor.options.hide_when_off`
+  - `Editor.options.hide_when_group_child`
+  - `Editor.options.show_volume_step_buttons`
+  - `Editor.options.use_volume_up_down`
+  - `Editor.options.use_experimental_lms`
+  - `Editor.ma_entities.ma_entity_id`
+  - `Editor.ma_entities.ma_favorite_button`
+  - `Editor.media_browser.name`
+  - `Editor.media_browser.entity_id`
+  - `Editor.media_browser.add`
+  - `Editor.media_browser.entry`
+  - `Editor.search.name`
+  - `Editor.search.entity_id`
+  - `Editor.search.add`
+  - `Editor.search.entry`
+  - `Editor.custom_buttons.name`
+  - `Editor.custom_buttons.icon`
+  - `Editor.custom_buttons.interactions`
+  - `Editor.custom_buttons.add`
+  - `Editor.custom_buttons.button`
+  - `Editor.entities_picker.name`
+  - `Editor.multi.default_media_player`
+  - `Editor.multi.media_players`
+  - `Editor.multi.media_player_fallback`
+  - `Editor.multi.ma_integration`
+  - `Editor.multi.group_media_player`
+  - `Editor.multi.enable_grouping`
+  - `Editor.multi.search_config`
+  - `Editor.multi.add_media_player`
+  - `Editor.multi.or`
+  - `Editor.multi.add_all_ma`
+  - `Editor.multi.advanced`
+  - `Editor.multi.height`
+  - `Editor.multi.transparent_background`
+  - `Editor.multi.default_tab`
+  - `Editor.multi.player_active_when`
+  - `Editor.select.panel`
+  - `Editor.select.card`
+  - `Editor.select.in_card`
+  - `Editor.select.large`
+  - `Editor.select.compact`
+  - `Editor.select.home`
+  - `Editor.select.search`
+  - `Editor.select.media_browser`
+  - `Editor.select.queue`
+  - `Editor.select.custom_buttons`
+  - `Editor.select.speaker_grouping`
+  - `Editor.select.playing`
+  - `Editor.select.playing_or_paused`
+  - `Editor.actions.tap_action`
+  - `Editor.actions.hold_action`
+  - `Editor.actions.double_tap_action`
 
 ### pt
 
@@ -47,3 +263,74 @@ _Total English keys: 69_
   - `Search.search_provider.title`
   - `Search.enqueue_mode.title`
   - `LyrionTrackInfo.empty_state`
+  - `Editor.common.media_player_entity`
+  - `Editor.common.name_optional`
+  - `Editor.common.name`
+  - `Editor.common.use_art_colors`
+  - `Editor.common.tap_opens_popup`
+  - `Editor.common.interactions`
+  - `Editor.common.tap_action_overridden`
+  - `Editor.common.speaker_group_config`
+  - `Editor.common.main_speaker_entity`
+  - `Editor.common.select_speakers`
+  - `Editor.common.ma_config`
+  - `Editor.common.lms_config`
+  - `Editor.common.lms_entity`
+  - `Editor.common.search_optional`
+  - `Editor.common.media_browser_optional`
+  - `Editor.common.custom_buttons_optional`
+  - `Editor.common.additional_options`
+  - `Editor.options.always_show_power_button`
+  - `Editor.options.always_show_custom_buttons`
+  - `Editor.options.hide_when_off`
+  - `Editor.options.hide_when_group_child`
+  - `Editor.options.show_volume_step_buttons`
+  - `Editor.options.use_volume_up_down`
+  - `Editor.options.use_experimental_lms`
+  - `Editor.ma_entities.ma_entity_id`
+  - `Editor.ma_entities.ma_favorite_button`
+  - `Editor.media_browser.name`
+  - `Editor.media_browser.entity_id`
+  - `Editor.media_browser.add`
+  - `Editor.media_browser.entry`
+  - `Editor.search.name`
+  - `Editor.search.entity_id`
+  - `Editor.search.add`
+  - `Editor.search.entry`
+  - `Editor.custom_buttons.name`
+  - `Editor.custom_buttons.icon`
+  - `Editor.custom_buttons.interactions`
+  - `Editor.custom_buttons.add`
+  - `Editor.custom_buttons.button`
+  - `Editor.entities_picker.name`
+  - `Editor.multi.default_media_player`
+  - `Editor.multi.media_players`
+  - `Editor.multi.media_player_fallback`
+  - `Editor.multi.ma_integration`
+  - `Editor.multi.group_media_player`
+  - `Editor.multi.enable_grouping`
+  - `Editor.multi.search_config`
+  - `Editor.multi.add_media_player`
+  - `Editor.multi.or`
+  - `Editor.multi.add_all_ma`
+  - `Editor.multi.advanced`
+  - `Editor.multi.height`
+  - `Editor.multi.transparent_background`
+  - `Editor.multi.default_tab`
+  - `Editor.multi.player_active_when`
+  - `Editor.select.panel`
+  - `Editor.select.card`
+  - `Editor.select.in_card`
+  - `Editor.select.large`
+  - `Editor.select.compact`
+  - `Editor.select.home`
+  - `Editor.select.search`
+  - `Editor.select.media_browser`
+  - `Editor.select.queue`
+  - `Editor.select.custom_buttons`
+  - `Editor.select.speaker_grouping`
+  - `Editor.select.playing`
+  - `Editor.select.playing_or_paused`
+  - `Editor.actions.tap_action`
+  - `Editor.actions.hold_action`
+  - `Editor.actions.double_tap_action`

--- a/src/components/i18n/en.json
+++ b/src/components/i18n/en.json
@@ -111,5 +111,98 @@
     "Paused": "Paused",
     "Stopped": "Stopped",
     "Unavailable": "Unavailable"
+  },
+  "Editor": {
+    "common": {
+      "media_player_entity": "Media Player Entity",
+      "name_optional": "Name (optional)",
+      "name": "Name",
+      "use_art_colors": "Use album art colors.",
+      "tap_opens_popup": "Tap opens popup.",
+      "interactions": "Interactions",
+      "tap_action_overridden": "Tap action overridden by \"tap opens popup\".",
+      "speaker_group_config": "Speaker Group Configuration (optional)",
+      "main_speaker_entity": "Main Speaker Entity ID (Optional)",
+      "select_speakers": "Select Speakers (including main speaker)",
+      "ma_config": "Music Assistant Configuration (optional)",
+      "lms_config": "LMS Configuration (optional)",
+      "lms_entity": "LMS Media Player Entity ID",
+      "search_optional": "Search (optional)",
+      "media_browser_optional": "Media Browser (optional)",
+      "custom_buttons_optional": "Custom Buttons (optional)",
+      "additional_options": "Additional options (optional)"
+    },
+    "options": {
+      "always_show_power_button": "Always show power button.",
+      "always_show_custom_buttons": "Always show custom buttons panel below card",
+      "hide_when_off": "Hide when media player is off",
+      "hide_when_group_child": "Hide when media player is a group child",
+      "show_volume_step_buttons": "Show volume step buttons + - on volume sliders",
+      "use_volume_up_down": "Use volume_up and volume_down services for step buttons (breaks volume sync when step buttons are used)",
+      "use_experimental_lms": "Use experimental LMS media browser (requires lyrion_cli integration)"
+    },
+    "ma_entities": {
+      "ma_entity_id": "Music Assistant Entity ID (Optional)",
+      "ma_favorite_button": "MA Favorite Button Entity ID (Optional)"
+    },
+    "media_browser": {
+      "name": "Name",
+      "entity_id": "Media Browser Entity ID",
+      "add": "Add Media Browser",
+      "entry": "Entry"
+    },
+    "search": {
+      "name": "Name",
+      "entity_id": "Media Player Entity ID (to search)",
+      "add": "Add Search",
+      "entry": "Entry"
+    },
+    "custom_buttons": {
+      "name": "Name",
+      "icon": "Icon",
+      "interactions": "Interactions",
+      "add": "Add Custom Button",
+      "button": "Button"
+    },
+    "entities_picker": {
+      "name": "Name"
+    },
+    "multi": {
+      "default_media_player": "Default Media Player (used when no media player is active)",
+      "media_players": "Media Players",
+      "media_player_fallback": "Media Player",
+      "ma_integration": "Music Assistant Integration (optional)",
+      "group_media_player": "Group Media Player (if different from above)",
+      "enable_grouping": "Enable speaker grouping (joining) for this player",
+      "search_config": "Search Configuration (optional) (not for music assistant)",
+      "add_media_player": "Add a new media player",
+      "or": "or",
+      "add_all_ma": "Add all Music Assistant media players",
+      "advanced": "Advanced",
+      "height": "Height",
+      "transparent_background": "Hide the card background on the home tab (massive player)",
+      "default_tab": "Default tab:",
+      "player_active_when": "Consider player active when:"
+    },
+    "select": {
+      "panel": "Panel",
+      "card": "Card",
+      "in_card": "In Card",
+      "large": "Large",
+      "compact": "Compact",
+      "home": "Home",
+      "search": "Search",
+      "media_browser": "Media Browser",
+      "queue": "Queue",
+      "custom_buttons": "Custom Buttons",
+      "speaker_grouping": "Speaker Grouping",
+      "playing": "Playing",
+      "playing_or_paused": "Playing or Paused"
+    },
+    "actions": {
+      "tap_action": "Tap Action",
+      "hold_action": "Hold Action",
+      "double_tap_action": "Double Tap Action"
+    }
   }
 }

--- a/src/components/i18n/he.json
+++ b/src/components/i18n/he.json
@@ -107,5 +107,98 @@
     "Paused": "מושהה",
     "Stopped": "נעצר",
     "Unavailable": "לא זמין"
+  },
+  "Editor": {
+    "common": {
+      "media_player_entity": "ישות נגן מדיה",
+      "name_optional": "שם (אופציונלי)",
+      "name": "שם",
+      "use_art_colors": "שימוש בצבעי עטיפת האלבום.",
+      "tap_opens_popup": "הקשה פותחת חלון קופץ.",
+      "interactions": "אינטראקציות",
+      "tap_action_overridden": "פעולת ההקשה נדרסת על ידי \"הקשה פותחת חלון קופץ\".",
+      "speaker_group_config": "הגדרת קבוצת רמקולים (אופציונלי)",
+      "main_speaker_entity": "מזהה ישות הרמקול הראשי (אופציונלי)",
+      "select_speakers": "בחירת רמקולים (כולל הרמקול הראשי)",
+      "ma_config": "הגדרת Music Assistant (אופציונלי)",
+      "lms_config": "הגדרת LMS (אופציונלי)",
+      "lms_entity": "מזהה ישות נגן המדיה של LMS",
+      "search_optional": "חיפוש (אופציונלי)",
+      "media_browser_optional": "דפדפן מדיה (אופציונלי)",
+      "custom_buttons_optional": "כפתורים מותאמים אישית (אופציונלי)",
+      "additional_options": "אפשרויות נוספות (אופציונלי)"
+    },
+    "options": {
+      "always_show_power_button": "להציג תמיד את לחצן ההפעלה.",
+      "always_show_custom_buttons": "להציג תמיד את לוח הכפתורים המותאמים מתחת לכרטיס",
+      "hide_when_off": "להסתיר כאשר נגן המדיה כבוי",
+      "hide_when_group_child": "להסתיר כאשר נגן המדיה הוא חבר בקבוצה",
+      "show_volume_step_buttons": "הצגת לחצני שינוי עוצמה ‎+ -‎ על פסי עוצמת הקול",
+      "use_volume_up_down": "שימוש בשירותי volume_up ו‑volume_down עבור לחצני שינוי העוצמה (פוגע בסנכרון העוצמה כאשר נעשה שימוש בלחצנים)",
+      "use_experimental_lms": "שימוש בדפדפן המדיה הניסיוני של LMS (דורש את האינטגרציה lyrion_cli)"
+    },
+    "ma_entities": {
+      "ma_entity_id": "מזהה ישות Music Assistant (אופציונלי)",
+      "ma_favorite_button": "מזהה ישות לחצן המועדפים של MA (אופציונלי)"
+    },
+    "media_browser": {
+      "name": "שם",
+      "entity_id": "מזהה ישות דפדפן המדיה",
+      "add": "הוספת דפדפן מדיה",
+      "entry": "רשומה"
+    },
+    "search": {
+      "name": "שם",
+      "entity_id": "מזהה ישות נגן המדיה (לחיפוש)",
+      "add": "הוספת חיפוש",
+      "entry": "רשומה"
+    },
+    "custom_buttons": {
+      "name": "שם",
+      "icon": "סמל",
+      "interactions": "אינטראקציות",
+      "add": "הוספת כפתור מותאם אישית",
+      "button": "כפתור"
+    },
+    "entities_picker": {
+      "name": "שם"
+    },
+    "multi": {
+      "default_media_player": "נגן מדיה ברירת מחדל (בשימוש כאשר אין נגן מדיה פעיל)",
+      "media_players": "נגני מדיה",
+      "media_player_fallback": "נגן מדיה",
+      "ma_integration": "אינטגרציית Music Assistant (אופציונלי)",
+      "group_media_player": "נגן מדיה לקבוצה (אם שונה מהאמור לעיל)",
+      "enable_grouping": "הפעלת קיבוץ רמקולים (צירוף) עבור נגן זה",
+      "search_config": "הגדרת חיפוש (אופציונלי) (לא עבור Music Assistant)",
+      "add_media_player": "הוספת נגן מדיה חדש",
+      "or": "או",
+      "add_all_ma": "הוספת כל נגני המדיה של Music Assistant",
+      "advanced": "מתקדם",
+      "height": "גובה",
+      "transparent_background": "הסתרת רקע הכרטיס בלשונית הבית (נגן Massive)",
+      "default_tab": "לשונית ברירת מחדל:",
+      "player_active_when": "להחשיב את הנגן כפעיל כאשר:"
+    },
+    "select": {
+      "panel": "פאנל",
+      "card": "כרטיס",
+      "in_card": "בתוך הכרטיס",
+      "large": "גדול",
+      "compact": "קומפקטי",
+      "home": "בית",
+      "search": "חיפוש",
+      "media_browser": "דפדפן מדיה",
+      "queue": "תור",
+      "custom_buttons": "כפתורים מותאמים",
+      "speaker_grouping": "קיבוץ רמקולים",
+      "playing": "מנגן",
+      "playing_or_paused": "מנגן או מושהה"
+    },
+    "actions": {
+      "tap_action": "פעולת הקשה",
+      "hold_action": "פעולת הקשה ממושכת",
+      "double_tap_action": "פעולת הקשה כפולה"
+    }
   }
 }

--- a/src/wrappers/CardEditorWrapper.tsx
+++ b/src/wrappers/CardEditorWrapper.tsx
@@ -5,6 +5,7 @@ import {
   GlanceGuard,
   HassContextProvider,
 } from "@components";
+import { IntlContextProvider } from "@components/i18n";
 
 export type EditorCardProps<T> = {
   config: T;
@@ -26,18 +27,20 @@ export class CardEditorWrapper<T> extends HTMLElement {
     this._config = config;
     if (!this._hass || !this.Card) return;
     render(
-      <EmotionContextProvider rootElement={this}>
-        <GlanceGuard>
-          <HassContextProvider hass={this._hass}>
-            <this.Card
-              config={this._config}
-              hass={this._hass}
-              rootElement={this}
-              {...this.extraProps}
-            />
-          </HassContextProvider>
-        </GlanceGuard>
-      </EmotionContextProvider>,
+      <IntlContextProvider locale={this._hass.language ?? "en"}>
+        <EmotionContextProvider rootElement={this}>
+          <GlanceGuard>
+            <HassContextProvider hass={this._hass}>
+              <this.Card
+                config={this._config}
+                hass={this._hass}
+                rootElement={this}
+                {...this.extraProps}
+              />
+            </HassContextProvider>
+          </GlanceGuard>
+        </EmotionContextProvider>
+      </IntlContextProvider>,
       this
     );
   }


### PR DESCRIPTION
## Summary

The visual **card editor** previously had all of its labels, section titles and select options **hardcoded in English**, and `CardEditorWrapper` was not wrapped in `IntlContextProvider` — so the editor could not be translated at all. This PR wires the editor into the existing i18n system and adds Hebrew for it.

- `CardEditorWrapper` now provides `IntlContextProvider` using the Home Assistant language, matching `CardWrapper`.
- Every user-facing string across the three card editors (Standard / Massive / Multi) and the shared form components (`FieldGroup*`, `EntitiesPicker`, `ActionsConfigurator`/`actionsSchema`) is moved into translation keys under a new `Editor` namespace in `en.json` and resolved via `useIntl().t()`.
- Adds the matching **Hebrew** translations for all new keys in `he.json`.
- Regenerates `TRANSLATION_STATUS.md`.

Other languages fall back to English automatically for the new keys (same behaviour as today), so this does not break any existing locale — it only adds keys for them to translate later.

## ⚠️ Depends on #485

This PR is **stacked on top of #485** ("Add Hebrew (he) translations"), which registers the `he` locale and adds the base `he.json`. Please merge **#485 first**. Until then this PR's diff also shows #485's commit; GitHub will collapse it to the editor-only changes once #485 is merged.

## Verification

- `yarn tsc` ✅
- `yarn lint` ✅
- `yarn test` — 260 tests pass ✅
- `yarn build` ✅